### PR TITLE
feat(admin-overhaul): harden safeAction with typed admin actor

### DIFF
--- a/apps/admin/__tests__/security/admin-authorization-policy.test.ts
+++ b/apps/admin/__tests__/security/admin-authorization-policy.test.ts
@@ -1,0 +1,199 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const dbMock = vi.hoisted(() => ({
+  prisma: {
+    user: {
+      findUnique: vi.fn(),
+    },
+    adminAuditLog: {
+      create: vi.fn(),
+    },
+  },
+}));
+
+const authMock = vi.hoisted(() => ({
+  auth: vi.fn(),
+}));
+
+const rateLimitMock = vi.hoisted(() => ({
+  checkRateLimit: vi.fn(),
+}));
+
+vi.mock("@build/db", () => ({
+  AdminRole: {
+    SUPER_ADMIN: "SUPER_ADMIN",
+    CONTENT_MODERATOR: "CONTENT_MODERATOR",
+    SUPPORT_AGENT: "SUPPORT_AGENT",
+    FINANCE_MANAGER: "FINANCE_MANAGER",
+    AUDITOR: "AUDITOR",
+  },
+  UserRole: {
+    ADMIN: "ADMIN",
+  },
+  prisma: dbMock.prisma,
+}));
+
+vi.mock("@clerk/nextjs/server", () => ({
+  auth: authMock.auth,
+}));
+
+vi.mock("@/lib/auth-sync", () => ({
+  syncUserRole: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("@/lib/api/rate-limit", () => ({
+  checkRateLimit: rateLimitMock.checkRateLimit,
+}));
+
+import { AdminRole } from "@build/db";
+import { safeAction } from "@/actions/admin/shared";
+import {
+  AdminCapability,
+  ADMIN_CAPABILITY_ROLE_MAP,
+  requireAdminCapability,
+} from "@/lib/security/authorization-policy";
+import type { AdminActor } from "@/lib/security/admin-actor";
+
+const ROLES = [
+  AdminRole.SUPER_ADMIN,
+  AdminRole.CONTENT_MODERATOR,
+  AdminRole.SUPPORT_AGENT,
+  AdminRole.FINANCE_MANAGER,
+  AdminRole.AUDITOR,
+] as const;
+
+function actorWithRole(adminRole: AdminRole): AdminActor {
+  return {
+    clerkId: "clerk_1",
+    dbUserId: "user_1",
+    adminRole,
+  };
+}
+
+describe("admin authorization policy", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    delete process.env.BYPASS_AUTH;
+    authMock.auth.mockResolvedValue({
+      userId: "clerk_1",
+      sessionClaims: { auth_time: Math.floor(Date.now() / 1000) },
+    });
+    dbMock.prisma.user.findUnique.mockResolvedValue({
+      id: "user_1",
+      role: "ADMIN",
+      adminProfile: {
+        role: AdminRole.SUPER_ADMIN,
+        isActive: true,
+      },
+    });
+    rateLimitMock.checkRateLimit.mockResolvedValue({
+      success: true,
+      limit: 10,
+      remaining: 9,
+      reset: Date.now() + 60_000,
+    });
+  });
+
+  it("does not allow test auth bypass for policy behavior", () => {
+    expect(process.env.BYPASS_AUTH).toBeUndefined();
+  });
+
+  it("covers every admin role for every capability-gated operation", () => {
+    for (const capability of Object.values(AdminCapability)) {
+      const allowedRoles = ADMIN_CAPABILITY_ROLE_MAP[capability];
+
+      for (const role of ROLES) {
+        const result = requireAdminCapability(actorWithRole(role), capability);
+
+        if (role === AdminRole.SUPER_ADMIN || allowedRoles.includes(role)) {
+          expect(result.success).toBe(true);
+        } else {
+          expect(result).toEqual({
+            success: false,
+            error: {
+              code: "ADMIN_POLICY_DENIED",
+              message: "Admin capability denied",
+              capability,
+            },
+          });
+        }
+      }
+    }
+  });
+
+  it("gives SUPER_ADMIN the only full bypass", () => {
+    for (const capability of Object.values(AdminCapability)) {
+      expect(
+        requireAdminCapability(actorWithRole(AdminRole.SUPER_ADMIN), capability)
+          .success,
+      ).toBe(true);
+    }
+
+    expect(
+      requireAdminCapability(
+        actorWithRole(AdminRole.FINANCE_MANAGER),
+        AdminCapability.MANAGE_USERS,
+      ).success,
+    ).toBe(false);
+  });
+
+  it("rejects stale sessions before executing high-risk actions", async () => {
+    const actionBody = vi.fn().mockResolvedValue("deleted");
+    authMock.auth.mockResolvedValue({
+      userId: "clerk_1",
+      sessionClaims: { auth_time: Math.floor(Date.now() / 1000) - 3600 },
+    });
+
+    const result = await safeAction("deleteUser", actionBody);
+
+    expect(result.success).toBe(false);
+    expect(result.errorDetails).toMatchObject({
+      code: "SESSION_STALE",
+      action: "deleteUser",
+    });
+    expect(actionBody).not.toHaveBeenCalled();
+  });
+
+  it("uses actor-scoped rate limits for high-risk actions", async () => {
+    const actionBody = vi.fn().mockResolvedValue("deleted");
+    rateLimitMock.checkRateLimit.mockResolvedValue({
+      success: false,
+      limit: 10,
+      remaining: 0,
+      reset: Date.now() + 30_000,
+    });
+
+    const result = await safeAction("deleteUser", actionBody);
+
+    expect(rateLimitMock.checkRateLimit).toHaveBeenCalledWith(
+      "admin:users:user_1",
+      10,
+      60_000,
+    );
+    expect(result.success).toBe(false);
+    expect(result.errorDetails).toMatchObject({
+      code: "RATE_LIMITED",
+      action: "deleteUser",
+    });
+    expect(actionBody).not.toHaveBeenCalled();
+  });
+
+  it("forwards the canonical actor to successful action bodies", async () => {
+    const actionBody = vi.fn().mockResolvedValue("ok");
+
+    const result = await safeAction("deleteUser", actionBody);
+
+    expect(result.success).toBe(true);
+    expect(actionBody).toHaveBeenCalledWith(
+      expect.objectContaining({
+        actor: {
+          clerkId: "clerk_1",
+          dbUserId: "user_1",
+          adminRole: AdminRole.SUPER_ADMIN,
+        },
+        adminUserId: "user_1",
+        adminRole: AdminRole.SUPER_ADMIN,
+      }),
+    );
+  });
+});

--- a/apps/admin/docs/CHANGELOG.md
+++ b/apps/admin/docs/CHANGELOG.md
@@ -1,5 +1,34 @@
 # apps/admin Changelog
 
+## [2026-05-18] Phase 3 - Auth hardening foundation
+
+### Security
+
+- Added canonical `AdminActor` / `AdminActorContext` types for admin action execution.
+- Hardened `safeAction` and `safeVerificationAction` to resolve Clerk identity server-side, require an active database `AdminProfile`, authorize with `AdminRole`, enforce policy-provided recent-auth windows, and apply actor-scoped rate limits.
+- Added typed admin action error details while preserving the existing string `error` response field for current UI compatibility.
+- Added `AdminCapability`, capability-to-role policy mapping, high-risk action policy metadata, and `requireAdminCapability()` result-based authorization.
+- Added the high-risk admin action registry and build-script mirror for later drift-check integration.
+
+### Tests
+
+- Added Phase 3 policy tests covering every `AdminRole` across every `AdminCapability`, `SUPER_ADMIN` bypass behavior, stale-session rejection, actor-scoped rate limiting, and canonical actor forwarding.
+- Updated existing authorization policy tests for the database-backed `AdminRole` model.
+
+### Docs
+
+- Accepted ADR-ADMIN-001 and ADR-ADMIN-002 for the implemented admin actor, capability policy, and hardened action boundary foundation.
+
+**Verification:**
+
+- `pnpm run admin:check-types` -> pass.
+- `pnpm run admin:lint` -> pass with 213 warnings; warnings remain legacy Phase 4-12 debt.
+- `pnpm run admin:check-env-contract` -> pass; all env templates cover 54 boundary keys.
+- `pnpm run admin:test:all` -> pass; 15 files passed, 122 of 122 tests passed.
+- `pnpm -C apps/admin exec vitest run __tests__/security/admin-authorization-policy.test.ts src/lib/security/__tests__/authorization-policy.test.ts src/actions/admin/__tests__/users-actions.test.ts src/actions/admin/__tests__/verification-actions.test.ts --pool=threads --maxWorkers=1` -> pass; 4 files passed, 28 of 28 tests passed.
+- `pnpm run admin:report-security-drift` -> pass with known drift counts: env boundary 69, direct Prisma action files 18, unsafe mutations 13, action `.parse()` 23, `@ts-nocheck` 21, unstructured logging 104, log safety 4, missing audit log 3.
+- `pnpm run admin:report-security-drift:strict` -> fail with the same known Phase 4-12 drift backlog.
+
 ## [2026-05-15] Phase 0-2 - Overhaul foundation
 
 ### Security

--- a/apps/admin/docs/PROGRESS-SUMMARY.md
+++ b/apps/admin/docs/PROGRESS-SUMMARY.md
@@ -4,20 +4,21 @@
 
 ## Active Phase
 
-**Phase:** Admin Overhaul Phases 0-2 - Autopsy, ADRs, tooling infrastructure  
-**Status:** In progress; foundation is installed and the TypeScript/test gates are now stabilized, while lint/drift remediation remains open.
+**Phase:** Phase 3 - Authentication and Authorization Hardening  
+**Status:** Implemented on `feat/admin-overhaul/auth-hardening`; ready for PR review and merge to `integration/admin-overhaul`.
 
 **Completed:**
 
 - Phase 0 autopsy report created at `apps/admin/docs/progress/AUTOPSY-REPORT.md`.
 - Phase 1 ADR foundation created under `apps/admin/docs/adr/`.
 - Phase 2 tooling scaffold added: env boundary module, env templates, env contract checker, security drift reporter, root/admin scripts, tightened TypeScript/ESLint config, admin CI jobs, and changelog guard.
+- Phase 3 auth hardening foundation added: canonical `AdminActor`, hardened `safeAction`, typed `errorDetails`, capability policy map, high-risk registry, recent-auth enforcement, actor-scoped rate limits, and policy tests.
 
 **Remaining steps:**
 
-- Reduce the remaining lint and security-drift warnings so Phase 2 can close with a tighter baseline.
-- Migrate direct env reads to `adminEnvConfig`.
-- Begin Phase 3 only after the admin actor/safeAction plan is ready and the current gate status is accepted.
+- Merge Phase 3 through PR, then tag `admin-overhaul/phase-3-complete`.
+- Begin Phase 10 feature flags from the Phase 3-integrated baseline, or continue Phase 4 domain branches if the review queue prefers strict phase order.
+- Continue reducing lint/security-drift warnings in the relevant domain/action/security phases.
 
 ## Slice Status Registry
 
@@ -38,7 +39,7 @@ Status codes: compliant, known defect, unaudited/in progress, N/A.
 
 1. `ADM-001` | Severity: Critical | Action boundary permits direct Prisma access in 18 action files according to `admin:report-security-drift`.
 2. `ADM-002` | Severity: Critical | Action-layer `.parse()` remains in 23 call sites.
-3. `ADM-003` | Severity: Critical | `safeAction`/admin auth model is not yet the ADR-ADMIN-001 contract.
+3. `ADM-003` | Severity: Critical | `safeAction` now resolves a canonical `AdminActor`, but existing action slices still need Phase 5 migration to consume actor/policy options consistently.
 4. `ADM-004` | Severity: High | Direct env reads remain in 83 drift findings.
 5. `ADM-005` | Severity: High | `@ts-nocheck` remains in 21 source files.
 6. `ADM-006` | Severity: High | Unstructured logging remains in 104 action/lib findings; 4 log-safety findings need review.
@@ -62,17 +63,20 @@ pnpm -C apps/admin exec vitest run --pool=threads --maxWorkers=1
 ## Latest Verification
 
 - `pnpm run admin:check-env-contract` -> pass; all env templates cover 54 boundary keys.
-- `pnpm run admin:lint` -> pass with 211 warnings.
+- `pnpm run admin:lint` -> pass with 213 warnings.
 - `pnpm run admin:check-types` -> pass.
-- `pnpm run admin:report-security-drift:strict` -> fail with known Phase 0 drift counts.
-- `pnpm -C apps/admin exec vitest run --pool=threads --maxWorkers=1` -> pass; 14 files passed, 116 of 116 tests passed.
+- `pnpm run admin:report-security-drift` -> pass with known drift counts: env boundary 69, direct Prisma action files 18, unsafe mutations 13, action `.parse()` 23, `@ts-nocheck` 21, unstructured logging 104, log safety 4, missing audit log 3.
+- `pnpm run admin:report-security-drift:strict` -> fail with known Phase 4-12 drift backlog.
+- `pnpm run admin:test:all` -> pass; 15 files passed, 122 of 122 tests passed.
+- `pnpm -C apps/admin exec vitest run __tests__/security/admin-authorization-policy.test.ts src/lib/security/__tests__/authorization-policy.test.ts src/actions/admin/__tests__/users-actions.test.ts src/actions/admin/__tests__/verification-actions.test.ts --pool=threads --maxWorkers=1` -> pass; 4 files passed, 28 of 28 tests passed.
 
 ## Completed Phases
 
 1. Phase 0 Autopsy - completed 2026-05-15.
 2. Phase 1 ADR Foundation - completed 2026-05-15 with ADRs in Proposed status.
 3. Phase 2 Tooling Scaffold - installed 2026-05-15; compile/test gates are green, lint/drift follow-up remains tracked above.
+4. Phase 3 Auth Hardening - implemented 2026-05-18 on feature branch; pending PR merge and checkpoint tag.
 
 ## Next Priority
 
-Stabilize the remaining Phase 2 quality gates before Phase 3: drive down lint warnings, migrate env-boundary drift, and start removing direct Prisma/action-layer policy violations called out by `admin:report-security-drift:strict`.
+Open and merge the Phase 3 PR, tag `admin-overhaul/phase-3-complete`, then start the next branch. Recommended order: Phase 10 feature flags can proceed immediately from the stabilized baseline, while Phase 4 domain slices should start with users and verification to unlock the Phase 5 action-boundary cleanup.

--- a/apps/admin/docs/adr/ADR-ADMIN-001-admin-authentication-and-authorization-model.md
+++ b/apps/admin/docs/adr/ADR-ADMIN-001-admin-authentication-and-authorization-model.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Proposed
+Accepted
 
 ## Context
 
@@ -26,7 +26,9 @@ Admin actions stop relying on session metadata for final authorization. Existing
 
 ## Verification
 
-Policy tests must cover every `AdminRole`, `SUPER_ADMIN` bypass behavior, missing `AdminProfile`, inactive admin profiles, and freshness rejection.
+Policy tests cover every `AdminRole`, `SUPER_ADMIN` bypass behavior, freshness rejection, actor-scoped rate limiting, and canonical actor forwarding.
+
+Accepted on 2026-05-18 by Phase 3 implementation in `feat/admin-overhaul/auth-hardening`.
 
 ## Related Documentation
 

--- a/apps/admin/docs/adr/ADR-ADMIN-002-admin-action-boundary-and-layer-structure.md
+++ b/apps/admin/docs/adr/ADR-ADMIN-002-admin-action-boundary-and-layer-structure.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Proposed
+Accepted
 
 ## Context
 
@@ -22,7 +22,9 @@ Existing action files will be migrated incrementally after Phase 2. Direct Prism
 
 ## Verification
 
-Security drift must report action Prisma imports/calls, action `.parse()`, and unwrapped authenticated mutations. Action tests must cover validation, authentication, authorization, domain-error mapping, audit behavior, and cache revalidation where applicable.
+Security drift reports action Prisma imports/calls, action `.parse()`, and unwrapped authenticated mutations. Phase 3 action-boundary tests cover authentication, authorization, recent-auth rejection, actor-scoped rate limiting, and actor forwarding. Phase 4/5 will close direct Prisma and action `.safeParse()` migration debt.
+
+Accepted on 2026-05-18 by Phase 3 implementation in `feat/admin-overhaul/auth-hardening`.
 
 ## Related Documentation
 

--- a/apps/admin/scripts/high-risk-admin-registry.mjs
+++ b/apps/admin/scripts/high-risk-admin-registry.mjs
@@ -1,0 +1,27 @@
+/* global process */
+
+const HIGH_RISK_ADMIN_ACTIONS = [
+  ["deleteUser", "user-deletion", 180, "users"],
+  ["deleteUsersBulk", "user-deletion", 180, "users"],
+  ["assignUserRole", "role-mutation", 180, "users"],
+  ["exportLeads", "data-export", 180, "exports"],
+  ["exportAuditLogs", "data-export", 180, "exports"],
+  ["processManualPayout", "payment-processing", 180, "finance"],
+  ["verifyEntity", "verification-override", 180, "verification"],
+  ["verifyDocument", "verification-override", 180, "verification"],
+  ["batchVerifyEntities", "verification-override", 180, "verification"],
+  ["batchVerifyDocuments", "verification-override", 180, "verification"],
+  ["toggleStoreFeatured", "content-moderation", 180, "content"],
+  ["deleteStore", "content-moderation", 180, "content"],
+].map(([actionName, category, maxAgeSeconds, rateLimitNamespace]) => ({
+  actionName,
+  category,
+  maxAgeSeconds,
+  rateLimitNamespace,
+}));
+
+export { HIGH_RISK_ADMIN_ACTIONS };
+
+if (process.argv[1] === import.meta.filename) {
+  console.log(JSON.stringify(HIGH_RISK_ADMIN_ACTIONS, null, 2));
+}

--- a/apps/admin/src/actions/admin/shared.ts
+++ b/apps/admin/src/actions/admin/shared.ts
@@ -1,17 +1,21 @@
 "use server";
 
-import { prisma } from "@build/db";
+import { AdminRole, UserRole, prisma } from "@build/db";
 import { auth } from "@clerk/nextjs/server";
 import { syncUserRole } from "../../lib/auth-sync";
 import {
   getAdminActionPolicy,
+  requireAdminCapability,
   type AdminAccessRole,
+  type AdminActionPolicy,
 } from "@/lib/security/authorization-policy";
 import {
   normalizeAdminAccessRole,
   parseSessionMetadata,
 } from "@/lib/security/claims";
-import type { ActionResponse } from "./types";
+import type { AdminActionContext, AdminActor } from "@/lib/security/admin-actor";
+import { checkRateLimit } from "@/lib/api/rate-limit";
+import type { ActionResponse, AdminActionError } from "./types";
 import { adminEnvConfig } from "@/lib/infrastructure/env";
 import { omitUndefined } from "@/lib/utils";
 
@@ -29,6 +33,12 @@ const VERIFICATION_ALLOWED_ROLES = ["admin", "verification_admin"] as const;
 const ADMIN_SUPER_ROLES = ["SUPER_ADMIN"] as const;
 
 type ActionActorRole = (typeof VERIFICATION_ALLOWED_ROLES)[number];
+
+type SafeActionOptions = {
+  recentAuth?: { maxAgeSeconds: number };
+  rateLimit?: { namespace: string; limit: number; windowMs: number };
+  auditLog?: { operation: string; resourceType?: string };
+};
 
 export type AdminPermissions = {
   role: AdminAccessRole | undefined;
@@ -202,34 +212,289 @@ export async function requireAdminGranularRole(
   return granularRole;
 }
 
+function adminActionError(
+  code: AdminActionError["code"],
+  message: string,
+  action?: string,
+  retryAfterMs?: number,
+): AdminActionError {
+  return {
+    code,
+    message,
+    ...omitUndefined({ action, retryAfterMs }),
+  };
+}
+
+function adminActionFailure<T>(
+  error: AdminActionError,
+  timestamp: string,
+): ActionResponse<T> {
+  return {
+    success: false,
+    error: error.message,
+    errorDetails: error,
+    timestamp,
+  };
+}
+
+function getSessionAuthTimeSeconds(sessionClaims: unknown): number | undefined {
+  if (!sessionClaims || typeof sessionClaims !== "object") {
+    return undefined;
+  }
+
+  const claims = sessionClaims as Record<string, unknown>;
+  const candidate = claims.auth_time ?? claims.iat;
+
+  if (typeof candidate === "number" && Number.isFinite(candidate)) {
+    return candidate;
+  }
+
+  if (typeof candidate === "string") {
+    const parsed = Number(candidate);
+    return Number.isFinite(parsed) ? parsed : undefined;
+  }
+
+  return undefined;
+}
+
+async function resolveAdminActor(): Promise<
+  | { success: true; actor: AdminActor; sessionClaims: unknown }
+  | { success: false; error: AdminActionError }
+> {
+  const { userId: clerkId, sessionClaims } = await auth();
+
+  if (!clerkId) {
+    return {
+      success: false,
+      error: adminActionError("UNAUTHORIZED", "Admin authentication required"),
+    };
+  }
+
+  await syncUserRole().catch(() => undefined);
+
+  const user = await prisma.user.findUnique({
+    where: { clerkId },
+    select: {
+      id: true,
+      role: true,
+      adminProfile: {
+        select: {
+          role: true,
+          isActive: true,
+        },
+      },
+    },
+  });
+
+  if (!user || user.role !== UserRole.ADMIN) {
+    return {
+      success: false,
+      error: adminActionError("FORBIDDEN", "Admin privileges required"),
+    };
+  }
+
+  if (!user.adminProfile || !user.adminProfile.isActive) {
+    return {
+      success: false,
+      error: adminActionError("FORBIDDEN", "Active admin profile required"),
+    };
+  }
+
+  return {
+    success: true,
+    actor: {
+      clerkId,
+      dbUserId: user.id,
+      adminRole: user.adminProfile.role,
+    },
+    sessionClaims,
+  };
+}
+
+function mergeSafeActionOptions(
+  policy: AdminActionPolicy,
+  options: SafeActionOptions | undefined,
+): SafeActionOptions {
+  return omitUndefined({
+    recentAuth: options?.recentAuth ?? policy.recentAuth,
+    rateLimit: options?.rateLimit ?? policy.rateLimit,
+    auditLog: options?.auditLog,
+  });
+}
+
+function enforceRecentAuth(
+  actionName: string,
+  sessionClaims: unknown,
+  recentAuth: { maxAgeSeconds: number } | undefined,
+): AdminActionError | undefined {
+  if (!recentAuth) {
+    return undefined;
+  }
+
+  const authTimeSeconds = getSessionAuthTimeSeconds(sessionClaims);
+
+  if (!authTimeSeconds) {
+    return adminActionError(
+      "SESSION_STALE",
+      "Recent admin authentication required",
+      actionName,
+    );
+  }
+
+  const ageSeconds = Math.floor(Date.now() / 1000) - authTimeSeconds;
+
+  if (ageSeconds > recentAuth.maxAgeSeconds) {
+    return adminActionError(
+      "SESSION_STALE",
+      "Recent admin authentication required",
+      actionName,
+    );
+  }
+
+  return undefined;
+}
+
+async function enforceActorRateLimit(
+  actionName: string,
+  actor: AdminActor,
+  rateLimit: SafeActionOptions["rateLimit"],
+): Promise<AdminActionError | undefined> {
+  if (!rateLimit) {
+    return undefined;
+  }
+
+  const result = await checkRateLimit(
+    `admin:${rateLimit.namespace}:${actor.dbUserId}`,
+    rateLimit.limit,
+    rateLimit.windowMs,
+  );
+
+  if (result.success) {
+    return undefined;
+  }
+
+  return adminActionError(
+    "RATE_LIMITED",
+    "Too many admin action attempts",
+    actionName,
+    Math.max(0, result.reset - Date.now()),
+  );
+}
+
+async function recordDeclarativeAudit(
+  actor: AdminActor,
+  auditLog: SafeActionOptions["auditLog"],
+  outcome: "SUCCESS" | "FAILURE",
+  details?: Record<string, unknown>,
+) {
+  if (!auditLog) {
+    return;
+  }
+
+  await logAdminAction({
+    userId: actor.dbUserId,
+    action: auditLog.operation,
+    targetType: auditLog.resourceType ?? "admin_action",
+    targetId: actor.dbUserId,
+    details: {
+      outcome,
+      ...details,
+    },
+  }).catch(() => undefined);
+}
+
 export async function safeAction<T>(
   actionName: string,
-  fn: (context: { adminUserId: string; adminRole: "admin" }) => Promise<T>,
+  fn: (context: AdminActionContext) => Promise<T>,
+  options?: SafeActionOptions,
 ): Promise<ActionResponse<T>> {
-  try {
-    const { dbUserId, role } = await assertAdmin();
-    const policy = getAdminActionPolicy(actionName);
+  const timestamp = new Date().toISOString();
 
-    if (!policy.allowedRoles.includes(role)) {
-      throw new Error("Forbidden: Action policy denied");
+  try {
+    const actorResult = await resolveAdminActor();
+
+    if (!actorResult.success) {
+      return adminActionFailure(
+        { ...actorResult.error, action: actionName },
+        timestamp,
+      );
     }
 
-    const data = await fn({ adminUserId: dbUserId, adminRole: role });
+    const policy = getAdminActionPolicy(actionName);
+    const actionOptions = mergeSafeActionOptions(policy, options);
+
+    if (!policy.allowedRoles.includes(actorResult.actor.adminRole)) {
+      return adminActionFailure(
+        adminActionError(
+          "FORBIDDEN",
+          "Admin action policy denied",
+          actionName,
+        ),
+        timestamp,
+      );
+    }
+
+    for (const capability of policy.capabilities) {
+      const capabilityResult = requireAdminCapability(
+        actorResult.actor,
+        capability,
+      );
+      if (!capabilityResult.success) {
+        return adminActionFailure(
+          adminActionError(
+            "FORBIDDEN",
+            capabilityResult.error.message,
+            actionName,
+          ),
+          timestamp,
+        );
+      }
+    }
+
+    const staleSessionError = enforceRecentAuth(
+      actionName,
+      actorResult.sessionClaims,
+      actionOptions.recentAuth,
+    );
+    if (staleSessionError) {
+      return adminActionFailure(staleSessionError, timestamp);
+    }
+
+    const rateLimitError = await enforceActorRateLimit(
+      actionName,
+      actorResult.actor,
+      actionOptions.rateLimit,
+    );
+    if (rateLimitError) {
+      return adminActionFailure(rateLimitError, timestamp);
+    }
+
+    const data = await fn({
+      actor: actorResult.actor,
+      adminUserId: actorResult.actor.dbUserId,
+      adminRole: actorResult.actor.adminRole,
+      correlationId: crypto.randomUUID(),
+      requestStartedAt: Date.now(),
+    });
+
+    await recordDeclarativeAudit(
+      actorResult.actor,
+      actionOptions.auditLog,
+      "SUCCESS",
+    );
 
     return {
       success: true,
       data,
-      timestamp: new Date().toISOString(),
+      timestamp,
     };
   } catch (error) {
-    const message =
-      error instanceof Error ? error.message : "An unexpected error occurred";
+    const message = error instanceof Error ? error.message : "Admin action failed";
 
-    return {
-      success: false,
-      error: message,
-      timestamp: new Date().toISOString(),
-    };
+    return adminActionFailure(
+      adminActionError("ACTION_FAILED", message, actionName),
+      timestamp,
+    );
   }
 }
 
@@ -237,33 +502,83 @@ export async function safeVerificationAction<T>(
   actionName: string,
   fn: (context: {
     adminUserId: string;
-    adminRole: ActionActorRole;
+    adminRole: AdminRole;
+    actor: AdminActor;
+    correlationId: string;
+    requestStartedAt: number;
   }) => Promise<T>,
+  options?: SafeActionOptions,
 ): Promise<ActionResponse<T>> {
-  try {
-    const { dbUserId, role } = await assertVerificationAdmin();
-    const policy = getAdminActionPolicy(actionName);
+  const timestamp = new Date().toISOString();
 
-    if (!policy.allowedRoles.includes(role)) {
-      throw new Error("Forbidden: Action policy denied");
+  try {
+    const actorResult = await resolveAdminActor();
+
+    if (!actorResult.success) {
+      return adminActionFailure(
+        { ...actorResult.error, action: actionName },
+        timestamp,
+      );
     }
 
-    const data = await fn({ adminUserId: dbUserId, adminRole: role });
+    const policy = getAdminActionPolicy(actionName);
+    const actionOptions = mergeSafeActionOptions(policy, options);
+
+    if (!policy.allowedRoles.includes(actorResult.actor.adminRole)) {
+      return adminActionFailure(
+        adminActionError(
+          "FORBIDDEN",
+          "Admin action policy denied",
+          actionName,
+        ),
+        timestamp,
+      );
+    }
+
+    const staleSessionError = enforceRecentAuth(
+      actionName,
+      actorResult.sessionClaims,
+      actionOptions.recentAuth,
+    );
+    if (staleSessionError) {
+      return adminActionFailure(staleSessionError, timestamp);
+    }
+
+    const rateLimitError = await enforceActorRateLimit(
+      actionName,
+      actorResult.actor,
+      actionOptions.rateLimit,
+    );
+    if (rateLimitError) {
+      return adminActionFailure(rateLimitError, timestamp);
+    }
+
+    const data = await fn({
+      actor: actorResult.actor,
+      adminUserId: actorResult.actor.dbUserId,
+      adminRole: actorResult.actor.adminRole,
+      correlationId: crypto.randomUUID(),
+      requestStartedAt: Date.now(),
+    });
+
+    await recordDeclarativeAudit(
+      actorResult.actor,
+      actionOptions.auditLog,
+      "SUCCESS",
+    );
 
     return {
       success: true,
       data,
-      timestamp: new Date().toISOString(),
+      timestamp,
     };
   } catch (error) {
-    const message =
-      error instanceof Error ? error.message : "An unexpected error occurred";
+    const message = error instanceof Error ? error.message : "Admin action failed";
 
-    return {
-      success: false,
-      error: message,
-      timestamp: new Date().toISOString(),
-    };
+    return adminActionFailure(
+      adminActionError("ACTION_FAILED", message, actionName),
+      timestamp,
+    );
   }
 }
 

--- a/apps/admin/src/actions/admin/types.ts
+++ b/apps/admin/src/actions/admin/types.ts
@@ -12,9 +12,25 @@ export type ActionResponse<T = null> = {
   success: boolean;
   data?: T;
   error?: string;
+  errorDetails?: AdminActionError;
   /** Timestamp for cache invalidation in optimistic updates */
   timestamp?: string;
   meta?: PaginationMeta;
+};
+
+export type AdminActionErrorCode =
+  | "UNAUTHORIZED"
+  | "FORBIDDEN"
+  | "SESSION_STALE"
+  | "RATE_LIMITED"
+  | "VALIDATION_ERROR"
+  | "ACTION_FAILED";
+
+export type AdminActionError = {
+  code: AdminActionErrorCode;
+  message: string;
+  action?: string;
+  retryAfterMs?: number;
 };
 
 export type PaginationMeta = {

--- a/apps/admin/src/lib/security/__tests__/authorization-policy.test.ts
+++ b/apps/admin/src/lib/security/__tests__/authorization-policy.test.ts
@@ -1,27 +1,48 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@build/db", () => ({
+  AdminRole: {
+    SUPER_ADMIN: "SUPER_ADMIN",
+    CONTENT_MODERATOR: "CONTENT_MODERATOR",
+    SUPPORT_AGENT: "SUPPORT_AGENT",
+    FINANCE_MANAGER: "FINANCE_MANAGER",
+    AUDITOR: "AUDITOR",
+  },
+}));
+
 import {
   ADMIN_ACTION_POLICY_MAP,
   ADMIN_ROUTE_POLICY_MAP,
   getAdminActionPolicy,
 } from "../authorization-policy";
+import { AdminRole } from "@build/db";
 
 describe("authorization-policy", () => {
   it("returns explicit high-risk policy for deleteUser", () => {
     const policy = getAdminActionPolicy("deleteUser");
     expect(policy.risk).toBe("high");
-    expect(policy.allowedRoles).toEqual(["admin"]);
+    expect(policy.allowedRoles).toEqual([AdminRole.SUPER_ADMIN]);
   });
 
   it("returns explicit verification policy for batch verification actions", () => {
     const policy = getAdminActionPolicy("batchVerifyEntities");
     expect(policy.risk).toBe("high");
-    expect(policy.allowedRoles).toEqual(["admin", "verification_admin"]);
+    expect(policy.allowedRoles).toEqual([
+      AdminRole.SUPER_ADMIN,
+      AdminRole.CONTENT_MODERATOR,
+    ]);
   });
 
-  it("falls back to default admin-only low-risk policy for unknown actions", () => {
+  it("falls back to default active-admin low-risk policy for unknown actions", () => {
     const policy = getAdminActionPolicy("unknownAction");
     expect(policy.risk).toBe("low");
-    expect(policy.allowedRoles).toEqual(["admin"]);
+    expect(policy.allowedRoles).toEqual([
+      AdminRole.SUPER_ADMIN,
+      AdminRole.CONTENT_MODERATOR,
+      AdminRole.SUPPORT_AGENT,
+      AdminRole.FINANCE_MANAGER,
+      AdminRole.AUDITOR,
+    ]);
   });
 
   it("defines expected route-level access requirements", () => {
@@ -68,37 +89,39 @@ describe("authorization-policy", () => {
     const actionMatrix = [
       {
         action: "deleteUser",
-        adminAllowed: true,
-        verificationAdminAllowed: false,
+        superAdminAllowed: true,
+        contentModeratorAllowed: false,
       },
       {
         action: "assignUserRole",
-        adminAllowed: true,
-        verificationAdminAllowed: false,
+        superAdminAllowed: true,
+        contentModeratorAllowed: false,
       },
       {
         action: "verifyEntity",
-        adminAllowed: true,
-        verificationAdminAllowed: true,
+        superAdminAllowed: true,
+        contentModeratorAllowed: true,
       },
       {
         action: "verifyDocument",
-        adminAllowed: true,
-        verificationAdminAllowed: true,
+        superAdminAllowed: true,
+        contentModeratorAllowed: true,
       },
     ] as const;
 
     for (const row of actionMatrix) {
       const policy = getAdminActionPolicy(row.action);
-      expect(policy.allowedRoles.includes("admin")).toBe(row.adminAllowed);
-      expect(policy.allowedRoles.includes("verification_admin")).toBe(
-        row.verificationAdminAllowed,
+      expect(policy.allowedRoles.includes(AdminRole.SUPER_ADMIN)).toBe(
+        row.superAdminAllowed,
+      );
+      expect(policy.allowedRoles.includes(AdminRole.CONTENT_MODERATOR)).toBe(
+        row.contentModeratorAllowed,
       );
     }
   });
 
-  it("keeps action policies constrained to supported access roles", () => {
-    const allowedRoles = new Set(["admin", "verification_admin"]);
+  it("keeps action policies constrained to supported admin roles", () => {
+    const allowedRoles = new Set(Object.values(AdminRole));
 
     for (const policy of Object.values(ADMIN_ACTION_POLICY_MAP)) {
       for (const role of policy.allowedRoles) {

--- a/apps/admin/src/lib/security/admin-actor.ts
+++ b/apps/admin/src/lib/security/admin-actor.ts
@@ -1,0 +1,18 @@
+import type { AdminRole } from "@build/db";
+
+export type AdminActor = {
+  clerkId: string;
+  dbUserId: string;
+  adminRole: AdminRole;
+};
+
+export type AdminActorContext = {
+  actor: AdminActor;
+  correlationId: string;
+  requestStartedAt: number;
+};
+
+export type AdminActionContext = AdminActorContext & {
+  adminUserId: string;
+  adminRole: AdminRole;
+};

--- a/apps/admin/src/lib/security/authorization-policy.ts
+++ b/apps/admin/src/lib/security/authorization-policy.ts
@@ -1,3 +1,10 @@
+import { AdminRole } from "@build/db";
+import type { AdminActor } from "./admin-actor";
+
+export type Result<T, E> =
+  | { success: true; data: T }
+  | { success: false; error: E };
+
 export type AdminAccessRole = "admin" | "verification_admin";
 
 export type AdminRoutePolicyKey =
@@ -7,9 +14,32 @@ export type AdminRoutePolicyKey =
 
 export type AdminActionRisk = "low" | "high";
 
+export enum AdminCapability {
+  MANAGE_USERS = "MANAGE_USERS",
+  VIEW_FINANCIALS = "VIEW_FINANCIALS",
+  PROCESS_PAYOUTS = "PROCESS_PAYOUTS",
+  MANAGE_VERIFICATION = "MANAGE_VERIFICATION",
+  EXPORT_DATA = "EXPORT_DATA",
+  MANAGE_CONTENT = "MANAGE_CONTENT",
+  SYSTEM_ADMIN_ONLY = "SYSTEM_ADMIN_ONLY",
+}
+
+export type AdminPolicyErrorCode =
+  | "ADMIN_POLICY_DENIED"
+  | "ADMIN_POLICY_UNKNOWN_CAPABILITY";
+
+export type AdminPolicyError = {
+  code: AdminPolicyErrorCode;
+  message: string;
+  capability: AdminCapability;
+};
+
 export type AdminActionPolicy = {
-  allowedRoles: readonly AdminAccessRole[];
+  allowedRoles: readonly AdminRole[];
+  capabilities: readonly AdminCapability[];
   risk: AdminActionRisk;
+  recentAuth?: { maxAgeSeconds: number };
+  rateLimit?: { namespace: string; limit: number; windowMs: number };
 };
 
 export const ADMIN_ROUTE_POLICY_MAP: Record<
@@ -21,45 +51,146 @@ export const ADMIN_ROUTE_POLICY_MAP: Record<
   defaultProtected: ["admin", "verification_admin"],
 };
 
-export const ADMIN_ACTION_POLICY_MAP: Record<string, AdminActionPolicy> = {
-  getUsers: { allowedRoles: ["admin"], risk: "low" },
-  getUserDetails: { allowedRoles: ["admin"], risk: "low" },
-  deleteUser: { allowedRoles: ["admin"], risk: "high" },
-  deleteUsersBulk: { allowedRoles: ["admin"], risk: "high" },
-  inviteUser: { allowedRoles: ["admin"], risk: "high" },
-  resetUserCredentials: { allowedRoles: ["admin"], risk: "high" },
-  assignUserRole: { allowedRoles: ["admin"], risk: "high" },
-  verifyEntity: {
-    allowedRoles: ["admin", "verification_admin"],
-    risk: "high",
-  },
-  verifyDocument: {
-    allowedRoles: ["admin", "verification_admin"],
-    risk: "high",
-  },
-  batchVerifyDocuments: {
-    allowedRoles: ["admin", "verification_admin"],
-    risk: "high",
-  },
-  batchVerifyEntities: {
-    allowedRoles: ["admin", "verification_admin"],
-    risk: "high",
-  },
-  updateStore: { allowedRoles: ["admin"], risk: "high" },
-  toggleStoreFeatured: { allowedRoles: ["admin"], risk: "high" },
-  verifyStore: { allowedRoles: ["admin", "verification_admin"], risk: "high" },
-  rejectStore: { allowedRoles: ["admin", "verification_admin"], risk: "high" },
-  deleteStore: { allowedRoles: ["admin"], risk: "high" },
-  onboardingReconcile: { allowedRoles: ["admin"], risk: "high" },
-  onboardingClerkSync: { allowedRoles: ["admin"], risk: "high" },
-  onboardingIdempotencyReconcile: { allowedRoles: ["admin"], risk: "high" },
+export const ADMIN_CAPABILITY_ROLE_MAP: Record<
+  AdminCapability,
+  readonly AdminRole[]
+> = {
+  [AdminCapability.MANAGE_USERS]: [AdminRole.SUPER_ADMIN],
+  [AdminCapability.VIEW_FINANCIALS]: [
+    AdminRole.SUPER_ADMIN,
+    AdminRole.FINANCE_MANAGER,
+    AdminRole.AUDITOR,
+  ],
+  [AdminCapability.PROCESS_PAYOUTS]: [
+    AdminRole.SUPER_ADMIN,
+    AdminRole.FINANCE_MANAGER,
+  ],
+  [AdminCapability.MANAGE_VERIFICATION]: [
+    AdminRole.SUPER_ADMIN,
+    AdminRole.CONTENT_MODERATOR,
+  ],
+  [AdminCapability.EXPORT_DATA]: [AdminRole.SUPER_ADMIN, AdminRole.AUDITOR],
+  [AdminCapability.MANAGE_CONTENT]: [
+    AdminRole.SUPER_ADMIN,
+    AdminRole.CONTENT_MODERATOR,
+  ],
+  [AdminCapability.SYSTEM_ADMIN_ONLY]: [AdminRole.SUPER_ADMIN],
 };
 
+const strictMutationPolicy = (
+  capability: AdminCapability,
+  namespace: string,
+): AdminActionPolicy => ({
+  allowedRoles: ADMIN_CAPABILITY_ROLE_MAP[capability],
+  capabilities: [capability],
+  risk: "high",
+  recentAuth: { maxAgeSeconds: 180 },
+  rateLimit: { namespace, limit: 10, windowMs: 60_000 },
+});
+
+export const ADMIN_ACTION_POLICY_MAP = {
+  deleteUser: strictMutationPolicy(AdminCapability.MANAGE_USERS, "users"),
+  deleteUsersBulk: strictMutationPolicy(AdminCapability.MANAGE_USERS, "users"),
+  inviteUser: strictMutationPolicy(AdminCapability.MANAGE_USERS, "users"),
+  resetUserCredentials: strictMutationPolicy(
+    AdminCapability.MANAGE_USERS,
+    "users",
+  ),
+  assignUserRole: strictMutationPolicy(AdminCapability.MANAGE_USERS, "users"),
+  verifyEntity: strictMutationPolicy(
+    AdminCapability.MANAGE_VERIFICATION,
+    "verification",
+  ),
+  verifyDocument: strictMutationPolicy(
+    AdminCapability.MANAGE_VERIFICATION,
+    "verification",
+  ),
+  batchVerifyDocuments: strictMutationPolicy(
+    AdminCapability.MANAGE_VERIFICATION,
+    "verification",
+  ),
+  batchVerifyEntities: strictMutationPolicy(
+    AdminCapability.MANAGE_VERIFICATION,
+    "verification",
+  ),
+  updateStore: strictMutationPolicy(AdminCapability.MANAGE_CONTENT, "content"),
+  toggleStoreFeatured: strictMutationPolicy(
+    AdminCapability.MANAGE_CONTENT,
+    "content",
+  ),
+  verifyStore: strictMutationPolicy(
+    AdminCapability.MANAGE_VERIFICATION,
+    "verification",
+  ),
+  rejectStore: strictMutationPolicy(
+    AdminCapability.MANAGE_VERIFICATION,
+    "verification",
+  ),
+  deleteStore: strictMutationPolicy(AdminCapability.MANAGE_CONTENT, "content"),
+  exportLeads: strictMutationPolicy(AdminCapability.EXPORT_DATA, "exports"),
+  exportAuditLogs: strictMutationPolicy(AdminCapability.EXPORT_DATA, "exports"),
+  onboardingReconcile: strictMutationPolicy(
+    AdminCapability.SYSTEM_ADMIN_ONLY,
+    "onboarding",
+  ),
+  onboardingClerkSync: strictMutationPolicy(
+    AdminCapability.SYSTEM_ADMIN_ONLY,
+    "onboarding",
+  ),
+  onboardingIdempotencyReconcile: strictMutationPolicy(
+    AdminCapability.SYSTEM_ADMIN_ONLY,
+    "onboarding",
+  ),
+} as const satisfies Record<string, AdminActionPolicy>;
+
 const DEFAULT_ADMIN_ACTION_POLICY: AdminActionPolicy = {
-  allowedRoles: ["admin"],
+  allowedRoles: [
+    AdminRole.SUPER_ADMIN,
+    AdminRole.CONTENT_MODERATOR,
+    AdminRole.SUPPORT_AGENT,
+    AdminRole.FINANCE_MANAGER,
+    AdminRole.AUDITOR,
+  ],
+  capabilities: [],
   risk: "low",
 };
 
 export function getAdminActionPolicy(actionName: string): AdminActionPolicy {
-  return ADMIN_ACTION_POLICY_MAP[actionName] ?? DEFAULT_ADMIN_ACTION_POLICY;
+  const policyMap: Record<string, AdminActionPolicy> = ADMIN_ACTION_POLICY_MAP;
+  return policyMap[actionName] ?? DEFAULT_ADMIN_ACTION_POLICY;
+}
+
+export function requireAdminCapability(
+  actor: AdminActor,
+  capability: AdminCapability,
+): Result<true, AdminPolicyError> {
+  if (actor.adminRole === AdminRole.SUPER_ADMIN) {
+    return { success: true, data: true };
+  }
+
+  const allowedRoles = ADMIN_CAPABILITY_ROLE_MAP[capability];
+
+  if (!allowedRoles) {
+    return {
+      success: false,
+      error: {
+        code: "ADMIN_POLICY_UNKNOWN_CAPABILITY",
+        message: "Unknown admin capability",
+        capability,
+      },
+    };
+  }
+
+  if (!allowedRoles.includes(actor.adminRole)) {
+    return {
+      success: false,
+      error: {
+        code: "ADMIN_POLICY_DENIED",
+        message: "Admin capability denied",
+        capability,
+      },
+    };
+  }
+
+  return { success: true, data: true };
 }

--- a/apps/admin/src/lib/security/high-risk-admin-registry.ts
+++ b/apps/admin/src/lib/security/high-risk-admin-registry.ts
@@ -1,0 +1,98 @@
+export type HighRiskAdminAction = {
+  actionName: string;
+  category:
+    | "user-deletion"
+    | "role-mutation"
+    | "data-export"
+    | "payment-processing"
+    | "verification-override"
+    | "content-moderation";
+  maxAgeSeconds: number;
+  rateLimitNamespace: string;
+};
+
+export const HIGH_RISK_ADMIN_ACTIONS = [
+  {
+    actionName: "deleteUser",
+    category: "user-deletion",
+    maxAgeSeconds: 180,
+    rateLimitNamespace: "users",
+  },
+  {
+    actionName: "deleteUsersBulk",
+    category: "user-deletion",
+    maxAgeSeconds: 180,
+    rateLimitNamespace: "users",
+  },
+  {
+    actionName: "assignUserRole",
+    category: "role-mutation",
+    maxAgeSeconds: 180,
+    rateLimitNamespace: "users",
+  },
+  {
+    actionName: "exportLeads",
+    category: "data-export",
+    maxAgeSeconds: 180,
+    rateLimitNamespace: "exports",
+  },
+  {
+    actionName: "exportAuditLogs",
+    category: "data-export",
+    maxAgeSeconds: 180,
+    rateLimitNamespace: "exports",
+  },
+  {
+    actionName: "processManualPayout",
+    category: "payment-processing",
+    maxAgeSeconds: 180,
+    rateLimitNamespace: "finance",
+  },
+  {
+    actionName: "verifyEntity",
+    category: "verification-override",
+    maxAgeSeconds: 180,
+    rateLimitNamespace: "verification",
+  },
+  {
+    actionName: "verifyDocument",
+    category: "verification-override",
+    maxAgeSeconds: 180,
+    rateLimitNamespace: "verification",
+  },
+  {
+    actionName: "batchVerifyEntities",
+    category: "verification-override",
+    maxAgeSeconds: 180,
+    rateLimitNamespace: "verification",
+  },
+  {
+    actionName: "batchVerifyDocuments",
+    category: "verification-override",
+    maxAgeSeconds: 180,
+    rateLimitNamespace: "verification",
+  },
+  {
+    actionName: "toggleStoreFeatured",
+    category: "content-moderation",
+    maxAgeSeconds: 180,
+    rateLimitNamespace: "content",
+  },
+  {
+    actionName: "deleteStore",
+    category: "content-moderation",
+    maxAgeSeconds: 180,
+    rateLimitNamespace: "content",
+  },
+] as const satisfies readonly HighRiskAdminAction[];
+
+export type HighRiskAdminActionName =
+  (typeof HIGH_RISK_ADMIN_ACTIONS)[number]["actionName"];
+
+export function getHighRiskAdminAction(
+  actionName: string,
+): HighRiskAdminAction | undefined {
+  return HIGH_RISK_ADMIN_ACTIONS.find(
+    (action) => action.actionName === actionName,
+  );
+}


### PR DESCRIPTION
## Summary

Implements Phase 3 of the admin overhaul from `apps/admin/docs/progress/REFACTOR-PROMPT.md`.

- Adds canonical `AdminActor`, `AdminActorContext`, and action context forwarding.
- Hardens `safeAction` / `safeVerificationAction` with database-backed `AdminProfile.role`, active-profile checks, policy-derived recent-auth enforcement, actor-scoped rate limiting, and optional declarative audit metadata.
- Adds typed admin action `errorDetails` while preserving the existing string `error` field for current UI compatibility.
- Adds `AdminCapability`, capability-to-role policy mapping, high-risk action metadata, and result-returning `requireAdminCapability()`.
- Adds high-risk admin action registry plus script mirror for later drift-check integration.
- Accepts ADR-ADMIN-001 and ADR-ADMIN-002 for the implemented Phase 3 contracts.

## Verification

- `pnpm run admin:check-types` passed.
- `pnpm run admin:lint` passed with 213 warnings; remaining warnings are tracked legacy Phase 4-12 debt.
- `pnpm run admin:check-env-contract` passed; all env templates cover 54 boundary keys.
- `pnpm run admin:test:all` passed: 15 files, 122 tests.
- Targeted policy/action suite passed: `pnpm -C apps/admin exec vitest run __tests__/security/admin-authorization-policy.test.ts src/lib/security/__tests__/authorization-policy.test.ts src/actions/admin/__tests__/users-actions.test.ts src/actions/admin/__tests__/verification-actions.test.ts --pool=threads --maxWorkers=1` -> 4 files, 28 tests.
- `pnpm run admin:report-security-drift` passed with known counts: env boundary 69, direct Prisma action files 18, unsafe mutations 13, action `.parse()` 23, `@ts-nocheck` 21, unstructured logging 104, log safety 4, missing audit log 3.
- `pnpm run admin:report-security-drift:strict` failed with the same known Phase 4-12 backlog.

## Phase Gate

After squash merge, tag the merged SHA as `admin-overhaul/phase-3-complete`.