### PR TITLE
feat(admin-overhaul): add users domain layer

### DIFF
--- a/apps/admin/docs/CHANGELOG.md
+++ b/apps/admin/docs/CHANGELOG.md
@@ -1,15 +1,39 @@
 # apps/admin Changelog
 
+## [2026-05-18] Phase 4 - Users domain slice
+
+### Added (Phase 4 - Users domain slice)
+
+- Added an admin-local `Result<T, E>` helper for domain/service boundaries.
+- Added the users domain contracts, repository, and service under `apps/admin/src/lib/domains/users`.
+- Added users repository contract tests covering Prisma query shape, soft-delete guards, and persistence-only mutation helpers.
+- Added users service policy tests covering list/query normalization, typed not-found errors, invitation authorization, and self-demotion prevention.
+
+### Changed (Phase 4 - Users domain slice)
+
+- Routed read-only admin users actions through the users service/domain boundary while leaving destructive action migration for the Phase 5 users action branch.
+- Preserved current UI response shapes for users list/detail actions while returning data from domain DTOs.
+
+**Verification:**
+
+- `pnpm run admin:check-types` -> pass.
+- `pnpm run admin:lint` -> pass with 213 warnings; warnings remain known Phase 4-12 debt.
+- `pnpm run admin:check-env-contract` -> pass; all env templates cover 59 boundary keys.
+- `pnpm run admin:test:all` -> pass; 18 files passed, 136 of 136 tests passed.
+- `pnpm -C apps/admin exec vitest run src/lib/domains/users/__tests__/service.test.ts src/lib/domains/users/__tests__/repository.test.ts src/actions/admin/__tests__/users-actions.test.ts --pool=threads --maxWorkers=1` -> pass; 3 files passed, 19 of 19 tests passed.
+- `pnpm run admin:report-security-drift` -> pass with known drift counts: env boundary 69, direct Prisma action files 18, unsafe mutations 13, action `.parse()` 23, `@ts-nocheck` 21, unstructured logging 104, log safety 4, missing audit log 3.
+- `pnpm run admin:report-security-drift:strict` -> fail with the same known Phase 4-12 drift backlog.
+
 ## [2026-05-18] Phase 10 - Feature flag rollout foundation
 
-### Added
+### Added (Phase 10 - Feature flag rollout foundation)
 
 - Added env-driven admin feature flags for v2 users, verification, finance dashboard, audit log UI, and structured logging rollout.
 - Added `/users-v2`, `/verifications-v2`, `/analytics-v2`, and `/audit-v2` route gates that redirect to the current routes when flags are disabled.
 - Added sidebar route switching so enabled v2 flags can steer navigation without removing current routes.
 - Added feature-flag tests covering default-off behavior, enabled route switching, and disabled-flag rollback behavior.
 
-### Docs
+### Docs (Phase 10 - Feature flag rollout foundation)
 
 - Documented Phase 10 rollback behavior in `PROGRESS-SUMMARY.md`.
 - Accepted ADR-ADMIN-009 for the env-driven strangler-fig feature flag foundation.
@@ -25,7 +49,7 @@
 
 ## [2026-05-18] Phase 3 - Auth hardening foundation
 
-### Security
+### Security (Phase 3 - Auth hardening foundation)
 
 - Added canonical `AdminActor` / `AdminActorContext` types for admin action execution.
 - Hardened `safeAction` and `safeVerificationAction` to resolve Clerk identity server-side, require an active database `AdminProfile`, authorize with `AdminRole`, enforce policy-provided recent-auth windows, and apply actor-scoped rate limits.
@@ -33,12 +57,12 @@
 - Added `AdminCapability`, capability-to-role policy mapping, high-risk action policy metadata, and `requireAdminCapability()` result-based authorization.
 - Added the high-risk admin action registry and build-script mirror for later drift-check integration.
 
-### Tests
+### Tests (Phase 3 - Auth hardening foundation)
 
 - Added Phase 3 policy tests covering every `AdminRole` across every `AdminCapability`, `SUPER_ADMIN` bypass behavior, stale-session rejection, actor-scoped rate limiting, and canonical actor forwarding.
 - Updated existing authorization policy tests for the database-backed `AdminRole` model.
 
-### Docs
+### Docs (Phase 3 - Auth hardening foundation)
 
 - Accepted ADR-ADMIN-001 and ADR-ADMIN-002 for the implemented admin actor, capability policy, and hardened action boundary foundation.
 
@@ -54,23 +78,23 @@
 
 ## [2026-05-15] Phase 0-2 - Overhaul foundation
 
-### Security
+### Security (Phase 0-2 - Overhaul foundation)
 
 - Added admin ADRs for authentication/authorization, action boundaries, observability, data handling, HTTP security, env access, UI contracts, audit logging, and strangler-fig rollout.
 - Added an admin security drift report with strict categories for env boundary drift, direct Prisma in actions, unsafe mutations, action `.parse()`, `@ts-nocheck`, unstructured logging, log safety, and missing audit coverage.
 
-### Fixed
+### Fixed (Phase 0-2 - Overhaul foundation)
 
 - Established canonical admin env templates and an env contract checker. `admin:check-env-contract` currently passes with 54 declared keys in each template.
 
-### Changed
+### Changed (Phase 0-2 - Overhaul foundation)
 
 - Tightened admin TypeScript configuration with `noUncheckedIndexedAccess`, `exactOptionalPropertyTypes`, and `docs` exclusion.
 - Hardened admin ESLint configuration with env-boundary, action-persistence-boundary, server-only UI import, explicit-any, and floating-promise checks.
 - Replaced the placeholder admin test script with Vitest-backed `test` and `test:all` scripts.
 - Aligned `apps/admin` package manager metadata with the root `pnpm@11.1.2`.
 
-### Added
+### Added (Phase 0-2 - Overhaul foundation)
 
 - `apps/admin/docs/progress/AUTOPSY-REPORT.md`.
 - Canonical `apps/admin/docs/adr/ADR-ADMIN-001` through `ADR-ADMIN-009`.
@@ -78,7 +102,7 @@
 - Admin root scripts: `admin:lint`, `admin:test`, `admin:test:all`, `admin:check-env-contract`, `admin:report-security-drift`, and `admin:report-security-drift:strict`.
 - CI jobs for admin validation and admin changelog guarding.
 
-### Docs
+### Docs (Phase 0-2 - Overhaul foundation)
 
 - Documented Phase 0 critical and high-severity findings with evidence and command output.
 

--- a/apps/admin/docs/PROGRESS-SUMMARY.md
+++ b/apps/admin/docs/PROGRESS-SUMMARY.md
@@ -4,8 +4,8 @@
 
 ## Active Phase
 
-**Phase:** Phase 10 - Feature Flag Rollout Foundation  
-**Status:** Implemented on `feat/admin-overhaul/feature-flags`; ready for PR review and merge to `integration/admin-overhaul`.
+**Phase:** Phase 4 - Domain Users Slice
+**Status:** Implemented on `feat/admin-overhaul/domain-users`; ready for PR review and merge to `integration/admin-overhaul`.
 
 **Completed:**
 
@@ -13,12 +13,14 @@
 - Phase 1 ADR foundation created under `apps/admin/docs/adr/`.
 - Phase 2 tooling scaffold added: env boundary module, env templates, env contract checker, security drift reporter, root/admin scripts, tightened TypeScript/ESLint config, admin CI jobs, and changelog guard.
 - Phase 3 auth hardening foundation added: canonical `AdminActor`, hardened `safeAction`, typed `errorDetails`, capability policy map, high-risk registry, recent-auth enforcement, actor-scoped rate limits, and policy tests.
-- Phase 10 feature flag foundation added: env-driven v2 flags, route gates, sidebar route switching, rollback docs, and feature-flag tests.
+- Phase 10 feature flag foundation added and tagged: env-driven v2 flags, route gates, sidebar route switching, rollback docs, and feature-flag tests.
+- Phase 4 users domain slice added: users contracts, repository, service, typed results, read-action service wiring, and users domain tests.
 
 **Remaining steps:**
 
-- Merge Phase 10 through PR, then tag `admin-overhaul/phase-10-complete`.
-- Begin Phase 4 domain branches from the Phase 10-integrated baseline, starting with users and verification.
+- Merge the Phase 4 users domain branch through PR.
+- Continue Phase 4 domain branches from the updated integration baseline in order: verification, content, finance, audit.
+- Tag `admin-overhaul/phase-4-complete` only after all Phase 4 domain slices are merged and verified.
 - Continue reducing lint/security-drift warnings in the relevant domain/action/security phases.
 
 ## Slice Status Registry
@@ -27,7 +29,7 @@ Status codes: compliant, known defect, unaudited/in progress, N/A.
 
 | Slice                        | Tier | Auth/Policy           | Actions      | Domain/Repo           | Tests                 | Observability | Overall               |
 | ---------------------------- | ---- | --------------------- | ------------ | --------------------- | --------------------- | ------------- | --------------------- |
-| users                        | T1   | known defect          | known defect | unaudited/in progress | known defect          | known defect  | known defect          |
+| users                        | T1   | known defect          | known defect | unaudited/in progress | compliant             | known defect  | unaudited/in progress |
 | verification                 | T1   | known defect          | known defect | unaudited/in progress | known defect          | known defect  | known defect          |
 | audit                        | T1   | known defect          | known defect | unaudited/in progress | known defect          | known defect  | known defect          |
 | GDPR/export                  | T1   | unaudited/in progress | N/A          | known defect          | unaudited/in progress | known defect  | known defect          |
@@ -63,14 +65,13 @@ pnpm -C apps/admin exec vitest run --pool=threads --maxWorkers=1
 
 ## Latest Verification
 
-- `pnpm run admin:check-env-contract` -> pass; all env templates cover 54 boundary keys.
-- `pnpm run admin:lint` -> pass with 213 warnings.
 - `pnpm run admin:check-types` -> pass.
-- `pnpm run admin:check-env-contract` -> pass; all env templates cover 59 boundary keys after Phase 10 flags.
+- `pnpm run admin:lint` -> pass with 213 warnings.
+- `pnpm run admin:check-env-contract` -> pass; all env templates cover 59 boundary keys.
 - `pnpm run admin:report-security-drift` -> pass with known drift counts: env boundary 69, direct Prisma action files 18, unsafe mutations 13, action `.parse()` 23, `@ts-nocheck` 21, unstructured logging 104, log safety 4, missing audit log 3.
 - `pnpm run admin:report-security-drift:strict` -> fail with known Phase 4-12 drift backlog.
-- `pnpm run admin:test:all` -> pass; 16 files passed, 125 of 125 tests passed.
-- `pnpm -C apps/admin exec vitest run __tests__/config/feature-flags.test.ts --pool=threads --maxWorkers=1` -> pass; 3 of 3 tests passed.
+- `pnpm run admin:test:all` -> pass; 18 files passed, 136 of 136 tests passed.
+- `pnpm -C apps/admin exec vitest run src/lib/domains/users/__tests__/service.test.ts src/lib/domains/users/__tests__/repository.test.ts src/actions/admin/__tests__/users-actions.test.ts --pool=threads --maxWorkers=1` -> pass; 3 files passed, 19 of 19 tests passed.
 
 ## Completed Phases
 
@@ -78,7 +79,8 @@ pnpm -C apps/admin exec vitest run --pool=threads --maxWorkers=1
 2. Phase 1 ADR Foundation - completed 2026-05-15 with ADRs in Proposed status.
 3. Phase 2 Tooling Scaffold - installed 2026-05-15; compile/test gates are green, lint/drift follow-up remains tracked above.
 4. Phase 3 Auth Hardening - completed 2026-05-18; checkpoint tag `admin-overhaul/phase-3-complete`.
-5. Phase 10 Feature Flags - implemented 2026-05-18 on feature branch; pending PR merge and checkpoint tag.
+5. Phase 10 Feature Flags - completed 2026-05-18; checkpoint tag `admin-overhaul/phase-10-complete`.
+6. Phase 4 Users Domain Slice - implemented 2026-05-18 on feature branch; pending PR merge. Phase 4 checkpoint tag waits for verification, content, finance, and audit domain slices.
 
 ## Rollback Contracts
 
@@ -94,4 +96,4 @@ Phase 10 flags are runtime-readable through `adminEnvConfig`; toggling them requ
 
 ## Next Priority
 
-Open and merge the Phase 10 PR, tag `admin-overhaul/phase-10-complete`, then start Phase 4 domain slices in order: users, verification, content, finance, audit.
+Open and merge the Phase 4 users domain PR, then continue Phase 4 domain slices in order: verification, content, finance, audit.

--- a/apps/admin/src/actions/admin/__tests__/users-actions.test.ts
+++ b/apps/admin/src/actions/admin/__tests__/users-actions.test.ts
@@ -1,6 +1,13 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("@build/db", () => ({
+  AdminRole: {
+    SUPER_ADMIN: "SUPER_ADMIN",
+    CONTENT_MODERATOR: "CONTENT_MODERATOR",
+    SUPPORT_AGENT: "SUPPORT_AGENT",
+    FINANCE_MANAGER: "FINANCE_MANAGER",
+    AUDITOR: "AUDITOR",
+  },
   prisma: {
     user: {
       findFirst: vi.fn(),

--- a/apps/admin/src/actions/admin/users.ts
+++ b/apps/admin/src/actions/admin/users.ts
@@ -10,31 +10,19 @@ import {
   type AssignableUserRole,
   isAssignableUserRole,
 } from "../../lib/users/user-roles";
+import {
+  usersService,
+  type AdminUserDetails,
+  type AdminUserListItem,
+} from "@/lib/domains/users";
+import { omitUndefined } from "@/lib/utils";
 
 // ============================================================================
 // Types
 // ============================================================================
 
-export type UserWithProfile = Prisma.UserGetPayload<{
-  include: {
-    professionalProfile: {
-      select: { companyName: true; verified: true };
-    };
-  };
-}>;
-
-export type UserDetails = Prisma.UserGetPayload<{
-  include: {
-    professionalProfile: true;
-    clientProfile: true;
-    orders: true;
-    reviews: {
-      include: {
-        professional: { select: { companyName: true } };
-      };
-    };
-  };
-}>;
+export type UserWithProfile = AdminUserListItem;
+export type UserDetails = AdminUserDetails;
 
 const USER_MUTATION_ROLES = ["SUPER_ADMIN"];
 const USER_IDEMPOTENCY_TTL_HOURS = 0.25;
@@ -65,53 +53,25 @@ export async function getUsers(
   sortBy: "createdAt" | "firstName" = "createdAt",
   sortOrder: "asc" | "desc" = "desc",
 ) {
-  return safeAction("getUsers", async () => {
-    const skip = (page - 1) * limit;
-
-    const where: Prisma.UserWhereInput = {
-      ...(search && {
-        OR: [
-          { email: { contains: search, mode: "insensitive" } },
-          { firstName: { contains: search, mode: "insensitive" } },
-          { lastName: { contains: search, mode: "insensitive" } },
-        ],
-      }),
-      ...(role && { role: normalizeUserRole(role) }),
-      ...(verified !== undefined && {
-        professionalProfile: {
-          verified,
-        },
-      }),
-    };
-
-    const orderBy: Prisma.UserOrderByWithRelationInput = {
-      [sortBy === "firstName" ? "firstName" : "createdAt"]: sortOrder,
-    };
-
-    const [users, total] = await Promise.all([
-      prisma.user.findMany({
-        where,
-        skip,
-        take: limit,
-        orderBy,
-        include: {
-          professionalProfile: {
-            select: { companyName: true, verified: true },
-          },
-        },
-      }),
-      prisma.user.count({ where }),
-    ]);
-
-    return {
-      users,
-      meta: {
-        total,
+  return safeAction("getUsers", async ({ actor }) => {
+    const result = await usersService.listAdminUsers(
+      actor,
+      omitUndefined({
         page,
         limit,
-        totalPages: Math.ceil(total / limit),
-      },
-    };
+        search,
+        role,
+        verified,
+        sortBy,
+        sortOrder,
+      }),
+    );
+
+    if (!result.ok) {
+      throw new Error(result.message);
+    }
+
+    return result.data;
   });
 }
 
@@ -119,28 +79,14 @@ export async function getUsers(
  * Fetches complete user details with related profiles and recent activity.
  */
 export async function getUserDetails(userId: string) {
-  return safeAction("getUserDetails", async () => {
-    const user = await prisma.user.findUnique({
-      where: { id: userId },
-      include: {
-        professionalProfile: true,
-        clientProfile: true,
-        orders: {
-          take: 5,
-          orderBy: { createdAt: "desc" },
-        },
-        reviews: {
-          take: 5,
-          orderBy: { createdAt: "desc" },
-          include: {
-            professional: { select: { companyName: true } },
-          },
-        },
-      },
-    });
+  return safeAction("getUserDetails", async ({ actor }) => {
+    const result = await usersService.getAdminUserDetails(actor, userId);
 
-    if (!user) throw new Error("User not found");
-    return user;
+    if (!result.ok) {
+      throw new Error(result.message);
+    }
+
+    return result.data;
   });
 }
 

--- a/apps/admin/src/lib/domains/users/__tests__/repository.test.ts
+++ b/apps/admin/src/lib/domains/users/__tests__/repository.test.ts
@@ -1,0 +1,118 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const prismaMock = vi.hoisted(() => ({
+  user: {
+    findMany: vi.fn(),
+    count: vi.fn(),
+    findFirst: vi.fn(),
+    delete: vi.fn(),
+    update: vi.fn(),
+  },
+}));
+
+vi.mock("@build/db", () => ({
+  prisma: prismaMock,
+}));
+
+import {
+  countUsers,
+  deleteUserById,
+  findUserByEmail,
+  findUserCredentialsTarget,
+  findUserDetailsById,
+  findUserIdentityTarget,
+  findUserRoleTarget,
+  listUsers,
+  markPasswordResetRequired,
+  updateUserRole,
+} from "../repository";
+
+describe("users repository contract", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("lists users with caller-provided where shape and profile include", async () => {
+    await listUsers({
+      where: { deletedAt: null, role: "CLIENT" },
+      skip: 10,
+      take: 5,
+      orderBy: { createdAt: "desc" },
+    });
+
+    expect(prismaMock.user.findMany).toHaveBeenCalledWith({
+      where: { deletedAt: null, role: "CLIENT" },
+      skip: 10,
+      take: 5,
+      orderBy: { createdAt: "desc" },
+      include: {
+        professionalProfile: {
+          select: { companyName: true, verified: true },
+        },
+      },
+    });
+  });
+
+  it("counts with caller-provided where shape", async () => {
+    await countUsers({ deletedAt: null });
+
+    expect(prismaMock.user.count).toHaveBeenCalledWith({
+      where: { deletedAt: null },
+    });
+  });
+
+  it("uses deletedAt null guard for detail and target lookups", async () => {
+    await findUserDetailsById("user_1");
+    await findUserIdentityTarget("user_2");
+    await findUserCredentialsTarget("user_3");
+    await findUserRoleTarget("user_4");
+
+    expect(prismaMock.user.findFirst).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({ where: { id: "user_1", deletedAt: null } }),
+    );
+    expect(prismaMock.user.findFirst).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({ where: { id: "user_2", deletedAt: null } }),
+    );
+    expect(prismaMock.user.findFirst).toHaveBeenNthCalledWith(
+      3,
+      expect.objectContaining({ where: { id: "user_3", deletedAt: null } }),
+    );
+    expect(prismaMock.user.findFirst).toHaveBeenNthCalledWith(
+      4,
+      expect.objectContaining({ where: { id: "user_4", deletedAt: null } }),
+    );
+  });
+
+  it("guards email lookup against soft-deleted users", async () => {
+    await findUserByEmail("new@example.com");
+
+    expect(prismaMock.user.findFirst).toHaveBeenCalledWith({
+      where: {
+        email: { equals: "new@example.com", mode: "insensitive" },
+        deletedAt: null,
+      },
+      select: { id: true },
+    });
+  });
+
+  it("keeps mutation repository methods persistence-only", async () => {
+    await deleteUserById("user_1");
+    await markPasswordResetRequired("user_2");
+    await updateUserRole("user_3", "ADMIN");
+
+    expect(prismaMock.user.delete).toHaveBeenCalledWith({
+      where: { id: "user_1" },
+    });
+    expect(prismaMock.user.update).toHaveBeenNthCalledWith(1, {
+      where: { id: "user_2" },
+      data: { passwordResetRequired: true },
+    });
+    expect(prismaMock.user.update).toHaveBeenNthCalledWith(2, {
+      where: { id: "user_3" },
+      data: { role: "ADMIN" },
+    });
+  });
+});
+

--- a/apps/admin/src/lib/domains/users/__tests__/service.test.ts
+++ b/apps/admin/src/lib/domains/users/__tests__/service.test.ts
@@ -1,0 +1,161 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const dbMock = vi.hoisted(() => ({
+  AdminRole: {
+    SUPER_ADMIN: "SUPER_ADMIN",
+    CONTENT_MODERATOR: "CONTENT_MODERATOR",
+    SUPPORT_AGENT: "SUPPORT_AGENT",
+    FINANCE_MANAGER: "FINANCE_MANAGER",
+    AUDITOR: "AUDITOR",
+  } as const,
+}));
+
+const repositoryMock = vi.hoisted(() => ({
+  listUsers: vi.fn(),
+  countUsers: vi.fn(),
+  findUserDetailsById: vi.fn(),
+  findUserByEmail: vi.fn(),
+}));
+
+vi.mock("@build/db", () => ({
+  AdminRole: dbMock.AdminRole,
+}));
+
+vi.mock("../repository", () => repositoryMock);
+
+import type { AdminUserActor } from "../contracts";
+import {
+  buildListUsersQuery,
+  getAdminUserDetails,
+  listAdminUsers,
+  prepareAssignUserRole,
+  prepareInviteUser,
+} from "../service";
+
+function actor(
+  adminRole: (typeof dbMock.AdminRole)[keyof typeof dbMock.AdminRole],
+): AdminUserActor {
+  return {
+    clerkId: "clerk_admin",
+    dbUserId: "admin_1",
+    adminRole,
+  };
+}
+
+describe("users domain service", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("builds list query with soft-delete guard, filters, pagination, and sorting", () => {
+    const result = buildListUsersQuery({
+      page: 2,
+      limit: 25,
+      search: " ada ",
+      role: "professional",
+      verified: true,
+      sortBy: "firstName",
+      sortOrder: "asc",
+    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+
+    expect(result.data.query).toEqual({
+      where: {
+        deletedAt: null,
+        OR: [
+          { email: { contains: "ada", mode: "insensitive" } },
+          { firstName: { contains: "ada", mode: "insensitive" } },
+          { lastName: { contains: "ada", mode: "insensitive" } },
+        ],
+        role: "PROFESSIONAL",
+        professionalProfile: { verified: true },
+      },
+      skip: 25,
+      take: 25,
+      orderBy: { firstName: "asc" },
+    });
+  });
+
+  it("rejects invalid role filters before repository access", async () => {
+    const result = await listAdminUsers(actor(dbMock.AdminRole.AUDITOR), {
+      role: "owner",
+    });
+
+    expect(result).toEqual({
+      ok: false,
+      error: "INVALID_INPUT",
+      message: "Invalid role. Allowed roles: CLIENT, PROFESSIONAL, ADMIN",
+    });
+    expect(repositoryMock.listUsers).not.toHaveBeenCalled();
+  });
+
+  it("returns paginated users", async () => {
+    repositoryMock.listUsers.mockResolvedValue([{ id: "user_1" }]);
+    repositoryMock.countUsers.mockResolvedValue(1);
+
+    const result = await listAdminUsers(actor(dbMock.AdminRole.AUDITOR), {
+      page: 1,
+      limit: 10,
+    });
+
+    expect(result).toEqual({
+      ok: true,
+      data: {
+        users: [{ id: "user_1" }],
+        meta: { total: 1, page: 1, limit: 10, totalPages: 1 },
+      },
+    });
+  });
+
+  it("returns user details or a typed not-found error", async () => {
+    repositoryMock.findUserDetailsById.mockResolvedValue(null);
+
+    const result = await getAdminUserDetails(
+      actor(dbMock.AdminRole.SUPPORT_AGENT),
+      "user_1",
+    );
+
+    expect(result).toEqual({
+      ok: false,
+      error: "USER_NOT_FOUND",
+      message: "User not found",
+    });
+  });
+
+  it("allows only SUPER_ADMIN to prepare user invitations", async () => {
+    const denied = await prepareInviteUser(actor(dbMock.AdminRole.FINANCE_MANAGER), {
+      email: "new@example.com",
+      role: "client",
+    });
+
+    expect(denied.ok).toBe(false);
+    if (denied.ok) return;
+    expect(denied.error).toBe("UNAUTHORIZED");
+
+    repositoryMock.findUserByEmail.mockResolvedValue(null);
+    const allowed = await prepareInviteUser(actor(dbMock.AdminRole.SUPER_ADMIN), {
+      email: " New.User@Example.COM ",
+      role: "professional",
+    });
+
+    expect(allowed).toEqual({
+      ok: true,
+      data: { email: "new.user@example.com", role: "PROFESSIONAL" },
+    });
+  });
+
+  it("blocks non-admin self-demotion during role assignment preparation", async () => {
+    const result = await prepareAssignUserRole(actor(dbMock.AdminRole.SUPER_ADMIN), {
+      userId: "admin_1",
+      role: "client",
+    });
+
+    expect(result).toEqual({
+      ok: false,
+      error: "SELF_ROLE_CHANGE_DENIED",
+      message: "Cannot remove your own admin platform role",
+    });
+  });
+});

--- a/apps/admin/src/lib/domains/users/contracts.ts
+++ b/apps/admin/src/lib/domains/users/contracts.ts
@@ -1,0 +1,108 @@
+import type { AdminRole, Prisma, UserRole } from "@build/db";
+import type { AdminActor } from "@/lib/security/admin-actor";
+import type { AssignableUserRole } from "@/lib/users/user-roles";
+
+export type AdminUserActor = AdminActor;
+
+export type UsersDomainErrorCode =
+  | "UNAUTHORIZED"
+  | "INVALID_INPUT"
+  | "USER_NOT_FOUND"
+  | "USER_ALREADY_EXISTS"
+  | "SELF_ROLE_CHANGE_DENIED"
+  | "REPOSITORY_ERROR";
+
+export type UsersDomainError = {
+  error: UsersDomainErrorCode;
+  message: string;
+  status?: number;
+  details?: unknown;
+};
+
+export type ListUsersInput = {
+  page?: number;
+  limit?: number;
+  search?: string;
+  role?: string;
+  verified?: boolean;
+  sortBy?: "createdAt" | "firstName";
+  sortOrder?: "asc" | "desc";
+};
+
+export type ListUsersQuery = {
+  where: Prisma.UserWhereInput;
+  orderBy: Prisma.UserOrderByWithRelationInput;
+  skip: number;
+  take: number;
+};
+
+export type AdminUserListItem = Prisma.UserGetPayload<{
+  include: {
+    professionalProfile: {
+      select: { companyName: true; verified: true };
+    };
+  };
+}>;
+
+export type AdminUserDetails = Prisma.UserGetPayload<{
+  include: {
+    professionalProfile: true;
+    clientProfile: true;
+    orders: true;
+    reviews: {
+      include: {
+        professional: { select: { companyName: true } };
+      };
+    };
+  };
+}>;
+
+export type ListUsersResult = {
+  users: AdminUserListItem[];
+  meta: {
+    total: number;
+    page: number;
+    limit: number;
+    totalPages: number;
+  };
+};
+
+export type UserIdentityTarget = {
+  id: string;
+  clerkId: string;
+  email: string;
+};
+
+export type UserCredentialsTarget = UserIdentityTarget & {
+  passwordResetRequired: boolean;
+};
+
+export type UserRoleTarget = UserIdentityTarget & {
+  role: UserRole;
+};
+
+export type InviteUserInput = {
+  email: string;
+  role: string;
+};
+
+export type NormalizedInviteUserInput = {
+  email: string;
+  role: AssignableUserRole;
+};
+
+export type AssignUserRoleInput = {
+  userId: string;
+  role: string;
+};
+
+export type NormalizedAssignUserRoleInput = {
+  userId: string;
+  role: AssignableUserRole;
+};
+
+export type UsersAuthorizationSnapshot = {
+  actorRole: AdminRole;
+  canManageUsers: boolean;
+};
+

--- a/apps/admin/src/lib/domains/users/index.ts
+++ b/apps/admin/src/lib/domains/users/index.ts
@@ -1,0 +1,4 @@
+export * from "./contracts";
+export * as usersRepository from "./repository";
+export * as usersService from "./service";
+

--- a/apps/admin/src/lib/domains/users/repository.ts
+++ b/apps/admin/src/lib/domains/users/repository.ts
@@ -1,0 +1,113 @@
+import { prisma } from "@build/db";
+import type {
+  AdminUserDetails,
+  ListUsersQuery,
+  UserCredentialsTarget,
+  UserIdentityTarget,
+  UserRoleTarget,
+} from "./contracts";
+
+export async function listUsers(query: ListUsersQuery) {
+  return prisma.user.findMany({
+    where: query.where,
+    skip: query.skip,
+    take: query.take,
+    orderBy: query.orderBy,
+    include: {
+      professionalProfile: {
+        select: { companyName: true, verified: true },
+      },
+    },
+  });
+}
+
+export async function countUsers(where: ListUsersQuery["where"]) {
+  return prisma.user.count({ where });
+}
+
+export async function findUserDetailsById(
+  userId: string,
+): Promise<AdminUserDetails | null> {
+  return prisma.user.findFirst({
+    where: { id: userId, deletedAt: null },
+    include: {
+      professionalProfile: true,
+      clientProfile: true,
+      orders: {
+        take: 5,
+        orderBy: { createdAt: "desc" },
+      },
+      reviews: {
+        take: 5,
+        orderBy: { createdAt: "desc" },
+        include: {
+          professional: { select: { companyName: true } },
+        },
+      },
+    },
+  });
+}
+
+export async function findUserIdentityTarget(
+  userId: string,
+): Promise<UserIdentityTarget | null> {
+  return prisma.user.findFirst({
+    where: { id: userId, deletedAt: null },
+    select: { id: true, clerkId: true, email: true },
+  });
+}
+
+export async function findUserCredentialsTarget(
+  userId: string,
+): Promise<UserCredentialsTarget | null> {
+  return prisma.user.findFirst({
+    where: { id: userId, deletedAt: null },
+    select: {
+      id: true,
+      clerkId: true,
+      email: true,
+      passwordResetRequired: true,
+    },
+  });
+}
+
+export async function findUserRoleTarget(
+  userId: string,
+): Promise<UserRoleTarget | null> {
+  return prisma.user.findFirst({
+    where: { id: userId, deletedAt: null },
+    select: { id: true, email: true, role: true, clerkId: true },
+  });
+}
+
+export async function findUserByEmail(email: string) {
+  return prisma.user.findFirst({
+    where: {
+      email: { equals: email, mode: "insensitive" },
+      deletedAt: null,
+    },
+    select: { id: true },
+  });
+}
+
+export async function deleteUserById(userId: string) {
+  return prisma.user.delete({ where: { id: userId } });
+}
+
+export async function markPasswordResetRequired(userId: string) {
+  return prisma.user.update({
+    where: { id: userId },
+    data: { passwordResetRequired: true },
+  });
+}
+
+export async function updateUserRole(
+  userId: string,
+  role: UserRoleTarget["role"],
+) {
+  return prisma.user.update({
+    where: { id: userId },
+    data: { role },
+  });
+}
+

--- a/apps/admin/src/lib/domains/users/service.ts
+++ b/apps/admin/src/lib/domains/users/service.ts
@@ -1,0 +1,222 @@
+import { AdminCapability, requireAdminCapability } from "@/lib/security/authorization-policy";
+import { err, ok, type Result } from "@/lib/errors/result";
+import {
+  ASSIGNABLE_USER_ROLES,
+  isAssignableUserRole,
+  type AssignableUserRole,
+} from "@/lib/users/user-roles";
+import type {
+  AdminUserDetails,
+  AdminUserActor,
+  AssignUserRoleInput,
+  InviteUserInput,
+  ListUsersInput,
+  ListUsersQuery,
+  ListUsersResult,
+  NormalizedAssignUserRoleInput,
+  NormalizedInviteUserInput,
+  UsersDomainError,
+} from "./contracts";
+import * as repository from "./repository";
+
+const DEFAULT_PAGE = 1;
+const DEFAULT_LIMIT = 10;
+const MAX_LIMIT = 100;
+
+function toDomainError(error: unknown): UsersDomainError {
+  return {
+    error: "REPOSITORY_ERROR",
+    message: error instanceof Error ? error.message : "Users repository failed",
+  };
+}
+
+function normalizeUserRole(role: string): Result<AssignableUserRole, UsersDomainError> {
+  const normalized = role.trim().toUpperCase();
+
+  if (!isAssignableUserRole(normalized)) {
+    return err({
+      error: "INVALID_INPUT",
+      message: `Invalid role. Allowed roles: ${ASSIGNABLE_USER_ROLES.join(", ")}`,
+    });
+  }
+
+  return ok(normalized);
+}
+
+function requireManageUsers(actor: AdminUserActor): Result<true, UsersDomainError> {
+  const result = requireAdminCapability(actor, AdminCapability.MANAGE_USERS);
+
+  if (result.success) {
+    return ok(true);
+  }
+
+  return err({
+    error: "UNAUTHORIZED",
+    message: "Admin user management permission required",
+    details: result.error,
+  });
+}
+
+export function buildListUsersQuery(input: ListUsersInput): Result<
+  { query: ListUsersQuery; page: number; limit: number },
+  UsersDomainError
+> {
+  const page = Math.max(1, Math.trunc(input.page ?? DEFAULT_PAGE));
+  const limit = Math.min(
+    MAX_LIMIT,
+    Math.max(1, Math.trunc(input.limit ?? DEFAULT_LIMIT)),
+  );
+  const search = input.search?.trim() ?? "";
+  const sortBy = input.sortBy === "firstName" ? "firstName" : "createdAt";
+  const sortOrder = input.sortOrder === "asc" ? "asc" : "desc";
+  const roleResult = input.role ? normalizeUserRole(input.role) : undefined;
+
+  if (roleResult && !roleResult.ok) {
+    return roleResult;
+  }
+
+  const where: ListUsersQuery["where"] = {
+    deletedAt: null,
+    ...(search && {
+      OR: [
+        { email: { contains: search, mode: "insensitive" } },
+        { firstName: { contains: search, mode: "insensitive" } },
+        { lastName: { contains: search, mode: "insensitive" } },
+      ],
+    }),
+    ...(roleResult?.ok ? { role: roleResult.data } : {}),
+    ...(input.verified !== undefined && {
+      professionalProfile: {
+        verified: input.verified,
+      },
+    }),
+  };
+
+  return ok({
+    page,
+    limit,
+    query: {
+      where,
+      skip: (page - 1) * limit,
+      take: limit,
+      orderBy: {
+        [sortBy]: sortOrder,
+      },
+    },
+  });
+}
+
+export async function listAdminUsers(
+  _actor: AdminUserActor,
+  input: ListUsersInput,
+): Promise<Result<ListUsersResult, UsersDomainError>> {
+  const queryResult = buildListUsersQuery(input);
+
+  if (!queryResult.ok) {
+    return queryResult;
+  }
+
+  try {
+    const [users, total] = await Promise.all([
+      repository.listUsers(queryResult.data.query),
+      repository.countUsers(queryResult.data.query.where),
+    ]);
+
+    return ok({
+      users,
+      meta: {
+        total,
+        page: queryResult.data.page,
+        limit: queryResult.data.limit,
+        totalPages: Math.ceil(total / queryResult.data.limit),
+      },
+    });
+  } catch (error) {
+    return err(toDomainError(error));
+  }
+}
+
+export async function getAdminUserDetails(
+  _actor: AdminUserActor,
+  userId: string,
+): Promise<Result<AdminUserDetails, UsersDomainError>> {
+  if (!userId.trim()) {
+    return err({ error: "INVALID_INPUT", message: "User ID is required" });
+  }
+
+  try {
+    const user = await repository.findUserDetailsById(userId);
+
+    if (!user) {
+      return err({ error: "USER_NOT_FOUND", message: "User not found" });
+    }
+
+    return ok(user);
+  } catch (error) {
+    return err(toDomainError(error));
+  }
+}
+
+export async function prepareInviteUser(
+  actor: AdminUserActor,
+  input: InviteUserInput,
+): Promise<Result<NormalizedInviteUserInput, UsersDomainError>> {
+  const authResult = requireManageUsers(actor);
+
+  if (!authResult.ok) {
+    return authResult;
+  }
+
+  const email = input.email.trim().toLowerCase();
+  const roleResult = normalizeUserRole(input.role || "");
+
+  if (!roleResult.ok) {
+    return roleResult;
+  }
+
+  if (!email || !email.includes("@")) {
+    return err({ error: "INVALID_INPUT", message: "Valid email is required" });
+  }
+
+  try {
+    const existingUser = await repository.findUserByEmail(email);
+
+    if (existingUser) {
+      return err({
+        error: "USER_ALREADY_EXISTS",
+        message: "A user with this email already exists",
+      });
+    }
+
+    return ok({ email, role: roleResult.data });
+  } catch (error) {
+    return err(toDomainError(error));
+  }
+}
+
+export async function prepareAssignUserRole(
+  actor: AdminUserActor,
+  input: AssignUserRoleInput,
+): Promise<Result<NormalizedAssignUserRoleInput, UsersDomainError>> {
+  const authResult = requireManageUsers(actor);
+
+  if (!authResult.ok) {
+    return authResult;
+  }
+
+  const roleResult = normalizeUserRole(input.role || "");
+
+  if (!roleResult.ok) {
+    return roleResult;
+  }
+
+  if (input.userId === actor.dbUserId && roleResult.data !== "ADMIN") {
+    return err({
+      error: "SELF_ROLE_CHANGE_DENIED",
+      message: "Cannot remove your own admin platform role",
+    });
+  }
+
+  return ok({ userId: input.userId, role: roleResult.data });
+}
+

--- a/apps/admin/src/lib/errors/result.ts
+++ b/apps/admin/src/lib/errors/result.ts
@@ -1,0 +1,25 @@
+export type DomainError<TCode extends string = string> = {
+  error: TCode;
+  message?: string;
+  status?: number;
+  details?: unknown;
+};
+
+export type Result<T, E extends object = DomainError> =
+  | { ok: true; data: T }
+  | ({ ok: false } & E);
+
+export function ok<T>(data: T): Result<T, never> {
+  return { ok: true, data };
+}
+
+export function err<E extends object>(error: E): Result<never, E> {
+  return { ok: false, ...error };
+}
+
+export function isOk<T, E extends object>(
+  result: Result<T, E>,
+): result is { ok: true; data: T } {
+  return result.ok;
+}
+


### PR DESCRIPTION
Phase: 4 - Domain users slice

Adds admin-local Result helper, users domain contracts/repository/service, read action wiring, repository contract tests, and users service policy tests.

Verification: admin:check-types passed; admin:lint passed with 213 warnings; admin:check-env-contract passed with 59 keys; admin:test:all passed with 136 tests; targeted users domain/action tests passed with 19 tests; admin:report-security-drift:strict still fails on known Phase 4-12 backlog.