### PR TITLE
feat(admin-overhaul): refactor users action slice onto domain boundaries

### DIFF
--- a/apps/admin/docs/CHANGELOG.md
+++ b/apps/admin/docs/CHANGELOG.md
@@ -1,5 +1,34 @@
 # apps/admin Changelog
 
+## [2026-05-18] Phase 5 - Users action slice
+
+### Security (Phase 5 - Users action slice)
+
+- Added `safeParse`-backed input validation for admin user detail, delete, bulk delete, invite, reset-credentials, and role-assignment actions.
+- Added declarative `auditLog` coverage in `safeAction` so high-risk user mutations can attach target IDs and non-PII details without manual audit calls.
+- Blocked self-deletion for admin user mutations to align single-delete behavior with the existing bulk-delete guard.
+
+### Changed (Phase 5 - Users action slice)
+
+- Removed direct Prisma access from `apps/admin/src/actions/admin/users.ts`; the action slice now delegates persistence to `usersRepository` and business rules to `usersService`.
+- Moved remaining users mutation preconditions into the users domain service, including target lookups, bulk-delete normalization, and reset/role-assignment preparation.
+- Updated the admin security drift reporter so declarative `auditLog:` usage counts as audit coverage for high-risk action files.
+
+### Tests (Phase 5 - Users action slice)
+
+- Reworked users action-boundary tests to assert service/repository delegation instead of action-layer Prisma calls.
+- Extended users domain service tests for delete preparation, bulk-delete normalization, reset preparation, and role-assignment target loading.
+
+**Verification:**
+
+- `pnpm run admin:check-types` -> pass.
+- `pnpm run admin:lint` -> pass with 211 warnings; warnings remain tracked Phase 5-12 backlog.
+- `pnpm run admin:check-env-contract` -> pass; all env templates cover 59 boundary keys.
+- `pnpm run admin:test:all` -> pass; 26 files passed, 174 of 174 tests passed.
+- `pnpm -C apps/admin exec vitest run src/lib/domains/users/__tests__/service.test.ts src/lib/domains/users/__tests__/repository.test.ts src/actions/admin/__tests__/users-actions.test.ts --pool=threads --maxWorkers=1` -> pass; 3 files passed, 22 of 22 tests passed.
+- `pnpm run admin:report-security-drift` -> pass with known drift counts: env boundary 69, direct Prisma action files 17, unsafe mutations 13, action `.parse()` 23, `@ts-nocheck` 21, unstructured logging 103, log safety 3, missing audit log 3.
+- `pnpm run admin:report-security-drift:strict` -> fail with the remaining Phase 5-12 drift backlog.
+
 ## [2026-05-18] Phase 4 - Audit domain slice
 
 ### Added (Phase 4 - Audit domain slice)

--- a/apps/admin/docs/PROGRESS-SUMMARY.md
+++ b/apps/admin/docs/PROGRESS-SUMMARY.md
@@ -4,8 +4,8 @@
 
 ## Active Phase
 
-**Phase:** Phase 4 - Domain Audit Slice
-**Status:** Implemented on stacked branch `feat/admin-overhaul/domain-audit`, based on the full Phase 4 domain stack because PR creation is blocked by an invalid local `gh` token.
+**Phase:** Phase 5 - Users action slice
+**Status:** Implemented on `feat/admin-overhaul/actions-users` from the Phase 4 integration baseline. Phase 4 is now merged on `integration/admin-overhaul` and tagged `admin-overhaul/phase-4-complete`.
 
 **Completed:**
 
@@ -19,17 +19,16 @@
 - Phase 4 content domain slice added: content contracts, repository, service, typed results, policy checks, moderation queue tests, and repository contract tests.
 - Phase 4 finance domain slice added: finance contracts, repository, service, typed results, policy checks, overview tests, and repository contract tests.
 - Phase 4 audit domain slice added: audit contracts, repository, service, typed results, policy checks, audit page/stat tests, and repository contract tests.
+- Phase 4 checkpoint merged on `integration/admin-overhaul` and tagged `admin-overhaul/phase-4-complete`.
+- Phase 5 users action slice added: `safeParse` action validation, service/repository delegation for all user mutations, declarative audit coverage, self-delete protection, and refreshed users action-boundary tests.
 
 **Remaining steps:**
 
-- Refresh GitHub CLI auth or open the users domain PR manually from the pushed branch, then merge it into `integration/admin-overhaul`.
-- Retarget/rebase `feat/admin-overhaul/domain-verification` onto the users-integrated baseline, then open and merge the verification domain PR.
-- Retarget/rebase `feat/admin-overhaul/domain-content` onto the verification-integrated baseline, then open and merge the content domain PR.
-- Retarget/rebase `feat/admin-overhaul/domain-finance` onto the content-integrated baseline, then open and merge the finance domain PR.
-- Retarget/rebase `feat/admin-overhaul/domain-audit` onto the finance-integrated baseline, then open and merge the audit domain PR.
-- After all Phase 4 domain PRs merge, run the full gate set on `integration/admin-overhaul` and tag `admin-overhaul/phase-4-complete`.
-- Tag `admin-overhaul/phase-4-complete` only after all Phase 4 domain slices are merged and verified.
-- Continue reducing lint/security-drift warnings in the relevant domain/action/security phases.
+- Open and merge the Phase 5 users action PR from `feat/admin-overhaul/actions-users` into `integration/admin-overhaul`.
+- Continue Track A with the verification action slice so direct Prisma and `.parse()` drift drop in the verification routes and queue actions.
+- Start Track C Phase 7 observability on a separate branch after the users slice is stable enough to consume the improved audit/logger primitives.
+- Start Track B Phase 6 token and route-boundary work after the current action slice lands, keeping UI-only changes isolated from Track A.
+- Continue reducing lint/security-drift warnings inside the active action/security slices instead of deferring new debt.
 
 ## Slice Status Registry
 
@@ -37,7 +36,7 @@ Status codes: compliant, known defect, unaudited/in progress, N/A.
 
 | Slice                        | Tier | Auth/Policy           | Actions      | Domain/Repo           | Tests                 | Observability | Overall               |
 | ---------------------------- | ---- | --------------------- | ------------ | --------------------- | --------------------- | ------------- | --------------------- |
-| users                        | T1   | known defect          | known defect | unaudited/in progress | compliant             | known defect  | unaudited/in progress |
+| users                        | T1   | compliant             | compliant    | compliant             | compliant             | known defect  | unaudited/in progress |
 | verification                 | T1   | known defect          | known defect | unaudited/in progress | compliant             | known defect  | unaudited/in progress |
 | audit                        | T1   | known defect          | known defect | unaudited/in progress | compliant             | known defect  | unaudited/in progress |
 | GDPR/export                  | T1   | unaudited/in progress | N/A          | known defect          | unaudited/in progress | known defect  | known defect          |
@@ -48,14 +47,14 @@ Status codes: compliant, known defect, unaudited/in progress, N/A.
 
 ## Open Defects
 
-1. `ADM-001` | Severity: Critical | Action boundary permits direct Prisma access in 18 action files according to `admin:report-security-drift`.
+1. `ADM-001` | Severity: Critical | Action boundary permits direct Prisma access in 17 action files according to `admin:report-security-drift`.
 2. `ADM-002` | Severity: Critical | Action-layer `.parse()` remains in 23 call sites.
-3. `ADM-003` | Severity: Critical | `safeAction` now resolves a canonical `AdminActor`, but existing action slices still need Phase 5 migration to consume actor/policy options consistently.
-4. `ADM-004` | Severity: High | Direct env reads remain in 83 drift findings.
+3. `ADM-003` | Severity: Critical | `safeAction` now resolves a canonical `AdminActor`, but remaining action slices still need Phase 5 migration to consume actor/policy options consistently.
+4. `ADM-004` | Severity: High | Direct env reads remain in 69 drift findings.
 5. `ADM-005` | Severity: High | `@ts-nocheck` remains in 21 source files.
-6. `ADM-006` | Severity: High | Unstructured logging remains in 104 action/lib findings; 4 log-safety findings need review.
+6. `ADM-006` | Severity: High | Unstructured logging remains in 103 action/lib findings; 3 log-safety findings need review.
 7. `ADM-007` | Severity: High | Strict TypeScript gate was stabilized, but adjacent legacy files still need contract cleanup to avoid regressions.
-8. `ADM-008` | Severity: Medium | Vitest aliasing and stale role expectations were fixed; keep the root admin suite green as verification flows evolve.
+8. `ADM-008` | Severity: Medium | Vitest aliasing and stale role expectations were fixed; keep the root admin suite green as action/verification flows evolve.
 9. `ADM-009` | Severity: Medium | ESLint passes but still reports 211 warnings after the Phase 2 rule hardening.
 10. `ADM-010` | Severity: Medium | High-risk verify route files are flagged as missing explicit audit-log integration.
 
@@ -74,12 +73,12 @@ pnpm -C apps/admin exec vitest run --pool=threads --maxWorkers=1
 ## Latest Verification
 
 - `pnpm run admin:check-types` -> pass.
-- `pnpm run admin:lint` -> pass with 213 warnings.
+- `pnpm run admin:lint` -> pass with 211 warnings.
 - `pnpm run admin:check-env-contract` -> pass; all env templates cover 59 boundary keys.
-- `pnpm run admin:report-security-drift` -> pass with known drift counts: env boundary 69, direct Prisma action files 18, unsafe mutations 13, action `.parse()` 23, `@ts-nocheck` 21, unstructured logging 104, log safety 4, missing audit log 3.
+- `pnpm run admin:report-security-drift` -> pass with known drift counts: env boundary 69, direct Prisma action files 17, unsafe mutations 13, action `.parse()` 23, `@ts-nocheck` 21, unstructured logging 103, log safety 3, missing audit log 3.
 - `pnpm run admin:report-security-drift:strict` -> fail with known Phase 4-12 drift backlog.
-- `pnpm run admin:test:all` -> pass; 26 files passed, 171 of 171 tests passed.
-- `pnpm -C apps/admin exec vitest run src/lib/domains/audit/__tests__/service.test.ts src/lib/domains/audit/__tests__/repository.test.ts --pool=threads --maxWorkers=1` -> pass; 2 files passed, 9 of 9 tests passed.
+- `pnpm run admin:test:all` -> pass; 26 files passed, 174 of 174 tests passed.
+- `pnpm -C apps/admin exec vitest run src/lib/domains/users/__tests__/service.test.ts src/lib/domains/users/__tests__/repository.test.ts src/actions/admin/__tests__/users-actions.test.ts --pool=threads --maxWorkers=1` -> pass; 3 files passed, 22 of 22 tests passed.
 
 ## Completed Phases
 
@@ -88,11 +87,8 @@ pnpm -C apps/admin exec vitest run --pool=threads --maxWorkers=1
 3. Phase 2 Tooling Scaffold - installed 2026-05-15; compile/test gates are green, lint/drift follow-up remains tracked above.
 4. Phase 3 Auth Hardening - completed 2026-05-18; checkpoint tag `admin-overhaul/phase-3-complete`.
 5. Phase 10 Feature Flags - completed 2026-05-18; checkpoint tag `admin-overhaul/phase-10-complete`.
-6. Phase 4 Users Domain Slice - implemented 2026-05-18 on feature branch; pending PR merge. Phase 4 checkpoint tag waits for verification, content, finance, and audit domain slices.
-7. Phase 4 Verification Domain Slice - implemented 2026-05-18 on stacked feature branch; pending users PR merge/retarget before verification PR.
-8. Phase 4 Content Domain Slice - implemented 2026-05-18 on stacked feature branch; pending users and verification PR merge/retarget before content PR.
-9. Phase 4 Finance Domain Slice - implemented 2026-05-18 on stacked feature branch; pending users, verification, and content PR merge/retarget before finance PR.
-10. Phase 4 Audit Domain Slice - implemented 2026-05-18 on stacked feature branch; pending prior Phase 4 PR merge/retarget before audit PR. Phase 4 checkpoint tag waits for all domain PRs to land on `integration/admin-overhaul`.
+6. Phase 4 Domain/Repository Layer - completed 2026-05-18; checkpoint tag `admin-overhaul/phase-4-complete`.
+7. Phase 5 Users Action Slice - implemented 2026-05-18 on `feat/admin-overhaul/actions-users`; pending PR merge and follow-on action slices for verification, audit/export, finance, content, and leads/services/professionals.
 
 ## Rollback Contracts
 
@@ -108,4 +104,4 @@ Phase 10 flags are runtime-readable through `adminEnvConfig`; toggling them requ
 
 ## Next Priority
 
-Open and merge the stacked Phase 4 domain PRs in order: users, verification, content, finance, audit. Then run integration gates and tag `admin-overhaul/phase-4-complete`.
+Continue Phase 5 on the verification action slice from the Phase 4 checkpoint, then sequence the remaining action branches: audit/GDPR/export, finance/analytics, stores/properties/projects, and leads/services/professionals.

--- a/apps/admin/scripts/report-security-drift.mjs
+++ b/apps/admin/scripts/report-security-drift.mjs
@@ -107,11 +107,17 @@ const unsafeMutations = actionFiles
 
 const missingAuditLog = actionFiles
   .filter((file) => /(delete|remove|verify|reject|approve|export|role)/i.test(file))
-  .filter((file) => !read(path.join(appRoot, file)).includes("logAdminAction"))
+  .filter((file) => {
+    const content = read(path.join(appRoot, file));
+    return (
+      !content.includes("logAdminAction") &&
+      !/\bauditLog\s*:/.test(content)
+    );
+  })
   .map((file) => ({
     file,
     line: 1,
-    sample: "high-risk action file without logAdminAction",
+    sample: "high-risk action file without audit coverage",
   }));
 
 const categories = {

--- a/apps/admin/src/actions/admin/__tests__/users-actions.test.ts
+++ b/apps/admin/src/actions/admin/__tests__/users-actions.test.ts
@@ -1,26 +1,65 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-vi.mock("@build/db", () => ({
-  AdminRole: {
-    SUPER_ADMIN: "SUPER_ADMIN",
-    CONTENT_MODERATOR: "CONTENT_MODERATOR",
-    SUPPORT_AGENT: "SUPPORT_AGENT",
-    FINANCE_MANAGER: "FINANCE_MANAGER",
-    AUDITOR: "AUDITOR",
-  },
-  prisma: {
-    user: {
-      findFirst: vi.fn(),
-      findUnique: vi.fn(),
-      update: vi.fn(),
+const usersServiceMock = vi.hoisted(() => ({
+  prepareInviteUser: vi.fn(),
+  prepareAssignUserRole: vi.fn(),
+  prepareDeleteUser: vi.fn(),
+  prepareDeleteUsersBulk: vi.fn(),
+  prepareResetUserCredentials: vi.fn(),
+}));
+
+const usersRepositoryMock = vi.hoisted(() => ({
+  deleteUserById: vi.fn(),
+  markPasswordResetRequired: vi.fn(),
+  updateUserRole: vi.fn(),
+}));
+
+const sharedMock = vi.hoisted(() => ({
+  safeAction: vi.fn(
+    async (
+      _name: string,
+      fn: (context: {
+        adminUserId: string;
+        adminRole: string;
+        actor: {
+          clerkId: string;
+          dbUserId: string;
+          adminRole: string;
+        };
+        correlationId: string;
+        requestStartedAt: number;
+      }) => Promise<unknown>,
+    ) => {
+      try {
+        const data = await fn({
+          adminUserId: "admin_user_1",
+          adminRole: "SUPER_ADMIN",
+          actor: {
+            clerkId: "clerk_admin_1",
+            dbUserId: "admin_user_1",
+            adminRole: "SUPER_ADMIN",
+          },
+          correlationId: "corr_1",
+          requestStartedAt: Date.now(),
+        });
+
+        return {
+          success: true,
+          data,
+          timestamp: new Date().toISOString(),
+        };
+      } catch (error) {
+        return {
+          success: false,
+          error:
+            error instanceof Error
+              ? error.message
+              : "An unexpected error occurred",
+        };
+      }
     },
-    idempotencyKey: {
-      findUnique: vi.fn(),
-      create: vi.fn(),
-      update: vi.fn(),
-      delete: vi.fn(),
-    },
-  },
+  ),
+  logAdminAction: vi.fn().mockResolvedValue(undefined),
 }));
 
 vi.mock("@clerk/nextjs/server", () => ({
@@ -37,62 +76,44 @@ vi.mock("@/lib/config/store.config", () => ({
   },
 }));
 
-vi.mock("../../lib/services/idempotency.service", () => ({
-  IdempotencyService: {
-    generateKey: vi.fn().mockReturnValue("scoped-idempotency-key"),
-    checkOrCreate: vi.fn().mockResolvedValue({ status: "new" }),
-    complete: vi.fn().mockResolvedValue(undefined),
-    fail: vi.fn().mockResolvedValue(undefined),
-  },
+vi.mock("../idempotency", () => ({
+  runWithIdempotency: vi.fn(
+    async <T,>(params: { run: () => Promise<T> }) => params.run(),
+  ),
 }));
 
-vi.mock("../shared", () => ({
-  safeAction: vi.fn(
-    async (
-      _name: string,
-      fn: (context: {
-        adminUserId: string;
-        adminRole: string;
-      }) => Promise<unknown>,
-    ) => {
-      try {
-        const data = await fn({
-          adminUserId: "admin_user_1",
-          adminRole: "admin",
-        });
-        return { success: true, data, timestamp: new Date().toISOString() };
-      } catch (error) {
-        return {
-          success: false,
-          error:
-            error instanceof Error
-              ? error.message
-              : "An unexpected error occurred",
-        };
-      }
-    },
-  ),
-  requireAdminGranularRole: vi.fn().mockResolvedValue("SUPER_ADMIN"),
-  logAdminAction: vi.fn().mockResolvedValue(undefined),
+vi.mock("../shared", () => sharedMock);
+
+vi.mock("@/lib/domains/users", () => ({
+  usersService: usersServiceMock,
+  usersRepository: usersRepositoryMock,
 }));
 
 import { clerkClient } from "@clerk/nextjs/server";
-import { prisma } from "@build/db";
-import { assignUserRole, inviteUser } from "../users";
+import { revalidatePath } from "next/cache";
+import {
+  assignUserRole,
+  deleteUser,
+  deleteUsersBulk,
+  inviteUser,
+  resetUserCredentials,
+} from "../users";
+import { safeAction } from "../shared";
 
 const IDEMPOTENCY_KEY = "idem-key-1";
 
 describe("admin users actions", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    vi.mocked(prisma.idempotencyKey.findUnique).mockResolvedValue(
-      null as never,
-    );
-    vi.mocked(prisma.idempotencyKey.create).mockResolvedValue({} as never);
-    vi.mocked(prisma.idempotencyKey.update).mockResolvedValue({} as never);
   });
 
-  it("rejects invite when role is not assignable", async () => {
+  it("rejects invite when the users service denies the input", async () => {
+    usersServiceMock.prepareInviteUser.mockResolvedValue({
+      ok: false,
+      error: "INVALID_INPUT",
+      message: "Invalid role. Allowed roles: CLIENT, PROFESSIONAL, ADMIN",
+    });
+
     const response = await inviteUser(
       {
         email: "new.user@example.com",
@@ -103,43 +124,17 @@ describe("admin users actions", () => {
 
     expect(response.success).toBe(false);
     expect(response.error).toContain("Invalid role");
+    expect(clerkClient).not.toHaveBeenCalled();
   });
 
-  it("rejects inviteUser when role input is only whitespace", async () => {
-    const response = await inviteUser(
-      {
+  it("creates a Clerk invitation from the normalized service payload", async () => {
+    usersServiceMock.prepareInviteUser.mockResolvedValue({
+      ok: true,
+      data: {
         email: "new.user@example.com",
-        role: "   ",
+        role: "ADMIN",
       },
-      IDEMPOTENCY_KEY,
-    );
-
-    expect(response.success).toBe(false);
-    expect(response.error).toContain("Invalid role. Allowed roles:");
-    expect(prisma.user.findFirst).not.toHaveBeenCalled();
-    expect(clerkClient).not.toHaveBeenCalled();
-  });
-
-  it("rejects inviteUser when email input is empty or whitespace", async () => {
-    for (const email of ["", "   "]) {
-      const response = await inviteUser(
-        {
-          email,
-          role: "ADMIN",
-        },
-        IDEMPOTENCY_KEY,
-      );
-
-      expect(response.success).toBe(false);
-      expect(response.error).toBe("Valid email is required");
-    }
-
-    expect(prisma.user.findFirst).not.toHaveBeenCalled();
-    expect(clerkClient).not.toHaveBeenCalled();
-  });
-
-  it("normalizes lowercase role input for invite and persists uppercase role metadata", async () => {
-    vi.mocked(prisma.user.findFirst).mockResolvedValue(null as never);
+    });
 
     const createInvitation = vi.fn().mockResolvedValue({
       id: "inv_123",
@@ -153,29 +148,42 @@ describe("admin users actions", () => {
 
     const response = await inviteUser(
       {
-        email: "new.user@example.com",
+        email: " New.User@example.com ",
         role: "admin",
       },
       IDEMPOTENCY_KEY,
     );
 
     expect(response.success).toBe(true);
-    expect(createInvitation).toHaveBeenCalledWith(
+    expect(createInvitation).toHaveBeenCalledWith({
+      emailAddress: "new.user@example.com",
+      publicMetadata: { role: "ADMIN" },
+    });
+    expect(safeAction).toHaveBeenCalledWith(
+      "inviteUser",
+      expect.any(Function),
       expect.objectContaining({
-        publicMetadata: { role: "ADMIN" },
+        auditLog: expect.objectContaining({
+          operation: "INVITE_USER",
+          resourceType: "user",
+        }),
       }),
     );
   });
 
-  it("normalizes lowercase role input for role assignment", async () => {
-    vi.mocked(prisma.user.findUnique).mockResolvedValue({
-      id: "user_1",
-      email: "user@example.com",
-      role: "CLIENT",
-      clerkId: "clerk_1",
-    } as never);
-
-    vi.mocked(prisma.user.update).mockResolvedValue({} as never);
+  it("updates user role through the repository and Clerk metadata", async () => {
+    usersServiceMock.prepareAssignUserRole.mockResolvedValue({
+      ok: true,
+      data: {
+        user: {
+          id: "user_1",
+          email: "user@example.com",
+          role: "CLIENT",
+          clerkId: "clerk_1",
+        },
+        role: "PROFESSIONAL",
+      },
+    });
 
     const updateUserMetadata = vi.fn().mockResolvedValue({});
     vi.mocked(clerkClient).mockResolvedValue({
@@ -191,26 +199,25 @@ describe("admin users actions", () => {
     );
 
     expect(response.success).toBe(true);
-    expect(prisma.user.update).toHaveBeenCalledWith(
-      expect.objectContaining({
-        where: { id: "user_1" },
-        data: { role: "PROFESSIONAL" },
-      }),
+    expect(usersRepositoryMock.updateUserRole).toHaveBeenCalledWith(
+      "user_1",
+      "PROFESSIONAL",
     );
     expect(updateUserMetadata).toHaveBeenCalledWith("clerk_1", {
       publicMetadata: {
         role: "PROFESSIONAL",
       },
     });
+    expect(revalidatePath).toHaveBeenCalledWith("/users");
+    expect(revalidatePath).toHaveBeenCalledWith("/users/user_1");
   });
 
-  it("blocks self-demotion from ADMIN role", async () => {
-    vi.mocked(prisma.user.findUnique).mockResolvedValue({
-      id: "admin_user_1",
-      email: "admin@example.com",
-      role: "ADMIN",
-      clerkId: "clerk_admin_1",
-    } as never);
+  it("blocks self-demotion when the users service rejects the assignment", async () => {
+    usersServiceMock.prepareAssignUserRole.mockResolvedValue({
+      ok: false,
+      error: "SELF_ROLE_CHANGE_DENIED",
+      message: "Cannot remove your own admin platform role",
+    });
 
     const response = await assignUserRole(
       "admin_user_1",
@@ -220,31 +227,135 @@ describe("admin users actions", () => {
 
     expect(response.success).toBe(false);
     expect(response.error).toBe("Cannot remove your own admin platform role");
-    expect(prisma.user.update).not.toHaveBeenCalled();
+    expect(usersRepositoryMock.updateUserRole).not.toHaveBeenCalled();
     expect(clerkClient).not.toHaveBeenCalled();
   });
 
-  it("rejects assignUserRole when role is not assignable", async () => {
-    const response = await assignUserRole(
-      "user_1",
-      "invalid_role",
+  it("deletes a user via repository persistence and ignores Clerk 404s", async () => {
+    usersServiceMock.prepareDeleteUser.mockResolvedValue({
+      ok: true,
+      data: {
+        id: "user_1",
+        clerkId: "clerk_1",
+        email: "user@example.com",
+      },
+    });
+
+    const deleteUserFromClerk = vi
+      .fn()
+      .mockRejectedValue({ status: 404 } as never);
+    vi.mocked(clerkClient).mockResolvedValue({
+      users: {
+        deleteUser: deleteUserFromClerk,
+      },
+    } as never);
+
+    const response = await deleteUser("user_1", IDEMPOTENCY_KEY);
+
+    expect(response.success).toBe(true);
+    expect(usersRepositoryMock.deleteUserById).toHaveBeenCalledWith("user_1");
+    expect(revalidatePath).toHaveBeenCalledWith("/users");
+    expect(vi.mocked(safeAction).mock.calls[0]?.[0]).toBe("deleteUser");
+    expect(vi.mocked(safeAction).mock.calls[0]?.[2]).toEqual(
+      expect.objectContaining({
+        auditLog: expect.objectContaining({
+          operation: "DELETE_USER",
+          resourceType: "user",
+        }),
+      }),
+    );
+  });
+
+  it("returns per-item bulk delete results without direct Prisma calls", async () => {
+    usersServiceMock.prepareDeleteUsersBulk.mockResolvedValue({
+      ok: true,
+      data: {
+        userIds: ["user_1", "admin_user_1", "user_404"],
+      },
+    });
+    usersServiceMock.prepareDeleteUser
+      .mockResolvedValueOnce({
+        ok: true,
+        data: {
+          id: "user_1",
+          clerkId: "clerk_1",
+          email: "user1@example.com",
+        },
+      })
+      .mockResolvedValueOnce({
+        ok: false,
+        error: "SELF_DELETE_DENIED",
+        message: "Cannot delete your own admin account",
+      })
+      .mockResolvedValueOnce({
+        ok: false,
+        error: "USER_NOT_FOUND",
+        message: "User not found",
+      });
+
+    const deleteUserFromClerk = vi.fn().mockResolvedValue({});
+    vi.mocked(clerkClient).mockResolvedValue({
+      users: {
+        deleteUser: deleteUserFromClerk,
+      },
+    } as never);
+
+    const response = await deleteUsersBulk(
+      ["user_1", "admin_user_1", "user_404"],
       IDEMPOTENCY_KEY,
     );
 
-    expect(response.success).toBe(false);
-    expect(response.error).toContain("Invalid role. Allowed roles:");
-    expect(prisma.user.findUnique).not.toHaveBeenCalled();
-    expect(prisma.user.update).not.toHaveBeenCalled();
-    expect(clerkClient).not.toHaveBeenCalled();
+    expect(response.success).toBe(true);
+    expect(response.data).toEqual({
+      summary: {
+        total: 3,
+        successful: 1,
+        failed: 2,
+      },
+      results: [
+        { userId: "user_1", email: "user1@example.com", success: true },
+        {
+          userId: "admin_user_1",
+          success: false,
+          error: "Cannot delete your own admin account",
+        },
+        {
+          userId: "user_404",
+          success: false,
+          error: "User not found",
+        },
+      ],
+    });
   });
 
-  it("rejects assignUserRole when role input is only whitespace", async () => {
-    const response = await assignUserRole("user_1", "    ", IDEMPOTENCY_KEY);
+  it("marks credentials reset through the repository and Clerk metadata", async () => {
+    usersServiceMock.prepareResetUserCredentials.mockResolvedValue({
+      ok: true,
+      data: {
+        id: "user_1",
+        clerkId: "clerk_1",
+        email: "user@example.com",
+        passwordResetRequired: false,
+      },
+    });
 
-    expect(response.success).toBe(false);
-    expect(response.error).toContain("Invalid role. Allowed roles:");
-    expect(prisma.user.findUnique).not.toHaveBeenCalled();
-    expect(prisma.user.update).not.toHaveBeenCalled();
-    expect(clerkClient).not.toHaveBeenCalled();
+    const updateUserMetadata = vi.fn().mockResolvedValue({});
+    vi.mocked(clerkClient).mockResolvedValue({
+      users: {
+        updateUserMetadata,
+      },
+    } as never);
+
+    const response = await resetUserCredentials("user_1", IDEMPOTENCY_KEY);
+
+    expect(response.success).toBe(true);
+    expect(usersRepositoryMock.markPasswordResetRequired).toHaveBeenCalledWith(
+      "user_1",
+    );
+    expect(updateUserMetadata).toHaveBeenCalledWith("clerk_1", {
+      publicMetadata: {
+        passwordResetRequired: true,
+      },
+    });
   });
 });

--- a/apps/admin/src/actions/admin/shared.ts
+++ b/apps/admin/src/actions/admin/shared.ts
@@ -40,7 +40,22 @@ type ActionActorRole = (typeof VERIFICATION_ALLOWED_ROLES)[number];
 type SafeActionOptions = {
   recentAuth?: { maxAgeSeconds: number };
   rateLimit?: { namespace: string; limit: number; windowMs: number };
-  auditLog?: { operation: string; resourceType?: string };
+  auditLog?: {
+    operation: string;
+    resourceType?: string;
+    getTargetId?: (payload: {
+      actor: AdminActor;
+      data: unknown;
+    }) => string;
+    getDetails?: (payload: {
+      actor: AdminActor;
+      data: unknown;
+    }) => Record<string, unknown> | undefined;
+    getReason?: (payload: {
+      actor: AdminActor;
+      data: unknown;
+    }) => string | undefined;
+  };
 };
 
 export type AdminPermissions = {
@@ -387,22 +402,25 @@ async function enforceActorRateLimit(
 async function recordDeclarativeAudit(
   actor: AdminActor,
   auditLog: SafeActionOptions["auditLog"],
-  outcome: "SUCCESS" | "FAILURE",
-  details?: Record<string, unknown>,
+  data: unknown,
 ) {
   if (!auditLog) {
     return;
   }
 
+  const targetId = auditLog.getTargetId?.({ actor, data }) ?? actor.dbUserId;
+  const details = auditLog.getDetails?.({ actor, data });
+  const reason = auditLog.getReason?.({ actor, data });
+
   await logAdminAction({
     userId: actor.dbUserId,
     action: auditLog.operation,
     targetType: auditLog.resourceType ?? "admin_action",
-    targetId: actor.dbUserId,
-    details: {
-      outcome,
-      ...details,
-    },
+    targetId,
+    ...omitUndefined({
+      details,
+      reason,
+    }),
   }).catch(() => undefined);
 }
 
@@ -479,7 +497,7 @@ export async function safeAction<T>(
     await recordDeclarativeAudit(
       actorResult.actor,
       actionOptions.auditLog,
-      "SUCCESS",
+      data,
     );
 
     return {
@@ -560,7 +578,7 @@ export async function safeVerificationAction<T>(
     await recordDeclarativeAudit(
       actorResult.actor,
       actionOptions.auditLog,
-      "SUCCESS",
+      data,
     );
 
     return {

--- a/apps/admin/src/actions/admin/users.ts
+++ b/apps/admin/src/actions/admin/users.ts
@@ -1,49 +1,69 @@
 "use server";
 
+import { z } from "zod";
 import { revalidatePath } from "next/cache";
 import { clerkClient } from "@clerk/nextjs/server";
-import { prisma } from "@build/db";
-import { safeAction, requireAdminGranularRole, logAdminAction } from "./shared";
+import { safeAction } from "./shared";
 import { runWithIdempotency } from "./idempotency";
 import {
-  ASSIGNABLE_USER_ROLES,
-  type AssignableUserRole,
-  isAssignableUserRole,
-} from "../../lib/users/user-roles";
-import {
+  usersRepository,
   usersService,
   type AdminUserDetails,
   type AdminUserListItem,
 } from "@/lib/domains/users";
 import { omitUndefined } from "@/lib/utils";
 
-// ============================================================================
-// Types
-// ============================================================================
-
 export type UserWithProfile = AdminUserListItem;
 export type UserDetails = AdminUserDetails;
 
-const USER_MUTATION_ROLES = ["SUPER_ADMIN"];
 const USER_IDEMPOTENCY_TTL_HOURS = 0.25;
+const NonEmptyStringSchema = z.string().trim().min(1);
+const IdempotencyKeySchema = z.string().trim().min(1, "Idempotency-Key is required");
+const InviteUserSchema = z
+  .object({
+    email: z.string().trim(),
+    role: z.string().trim(),
+  })
+  .strict();
+const AssignUserRoleSchema = z
+  .object({
+    userId: NonEmptyStringSchema,
+    role: z.string().trim(),
+  })
+  .strict();
+const DeleteUsersBulkSchema = z
+  .object({
+    userIds: z.array(z.string()),
+  })
+  .strict();
 
-function normalizeUserRole(role: string): AssignableUserRole {
-  const normalized = role.trim().toUpperCase();
-  if (!isAssignableUserRole(normalized)) {
-    throw new Error(
-      `Invalid role. Allowed roles: ${ASSIGNABLE_USER_ROLES.join(", ")}`,
-    );
+function parseActionInput<T>(
+  schema: z.ZodType<T>,
+  input: unknown,
+  fallbackMessage: string,
+): T {
+  const result = schema.safeParse(input);
+
+  if (!result.success) {
+    throw new Error(result.error.issues[0]?.message ?? fallbackMessage);
   }
-  return normalized;
+
+  return result.data;
 }
 
-// ============================================================================
-// Actions
-// ============================================================================
+function buildClerkDeleteError(error: unknown) {
+  const status =
+    typeof error === "object" && error && "status" in error
+      ? (error as { status?: number }).status
+      : undefined;
 
-/**
- * Fetches a paginated list of users with filtering and sorting.
- */
+  if (status === 404) {
+    return { ignored: true };
+  }
+
+  throw new Error("Failed to remove user from identity provider");
+}
+
 export async function getUsers(
   page = 1,
   limit = 10,
@@ -75,12 +95,15 @@ export async function getUsers(
   });
 }
 
-/**
- * Fetches complete user details with related profiles and recent activity.
- */
-export async function getUserDetails(userId: string) {
+export async function getUserDetails(targetUserId: string) {
   return safeAction("getUserDetails", async ({ actor }) => {
-    const result = await usersService.getAdminUserDetails(actor, userId);
+    const parsedUserId = parseActionInput(
+      NonEmptyStringSchema,
+      targetUserId,
+      "User ID is required",
+    );
+
+    const result = await usersService.getAdminUserDetails(actor, parsedUserId);
 
     if (!result.ok) {
       throw new Error(result.message);
@@ -90,377 +113,387 @@ export async function getUserDetails(userId: string) {
   });
 }
 
-/**
- * Permanently removes a user from both Clerk and database.
- * Returns the deleted user ID for optimistic UI updates.
- *
- * @warning This is a destructive action with cascading deletes.
- */
 export async function deleteUser(userId: string, idempotencyKey: string) {
-  return safeAction("deleteUser", async ({ adminUserId }) => {
-    await requireAdminGranularRole(USER_MUTATION_ROLES, adminUserId);
+  return safeAction(
+    "deleteUser",
+    async ({ actor, adminUserId }) => {
+      const parsedUserId = parseActionInput(
+        NonEmptyStringSchema,
+        userId,
+        "User ID is required",
+      );
+      const parsedIdempotencyKey = parseActionInput(
+        IdempotencyKeySchema,
+        idempotencyKey,
+        "Idempotency-Key is required",
+      );
 
-    return runWithIdempotency({
-      adminUserId,
-      actionName: "deleteUser",
-      idempotencyKey,
-      resourceId: userId,
-      ttlHours: USER_IDEMPOTENCY_TTL_HOURS,
-      run: async () => {
-        const user = await prisma.user.findUnique({
-          where: { id: userId },
-          select: { id: true, clerkId: true, email: true },
-        });
+      return runWithIdempotency({
+        adminUserId,
+        actionName: "deleteUser",
+        idempotencyKey: parsedIdempotencyKey,
+        resourceId: parsedUserId,
+        ttlHours: USER_IDEMPOTENCY_TTL_HOURS,
+        run: async () => {
+          const result = await usersService.prepareDeleteUser(actor, parsedUserId);
 
-        if (!user) throw new Error("User not found");
-
-        try {
-          const client = await clerkClient();
-          await client.users.deleteUser(user.clerkId);
-        } catch (clerkError: unknown) {
-          const error = clerkError as { status?: number };
-          if (error.status !== 404) {
-            console.error("Clerk delete error:", clerkError);
-            throw new Error("Failed to remove user from identity provider");
+          if (!result.ok) {
+            throw new Error(result.message);
           }
-        }
 
-        await prisma.user.delete({ where: { id: userId } });
+          const user = result.data;
 
-        await logAdminAction({
-          userId: adminUserId,
-          action: "DELETE_USER",
-          targetType: "user",
-          targetId: user.id,
-          details: {
+          try {
+            const client = await clerkClient();
+            await client.users.deleteUser(user.clerkId);
+          } catch (error) {
+            buildClerkDeleteError(error);
+          }
+
+          await usersRepository.deleteUserById(user.id);
+
+          revalidatePath("/users");
+
+          return {
+            deleted: true,
+            userId: user.id,
             email: user.email,
-          },
-        });
-
-        revalidatePath("/users");
-
-        return {
+          };
+        },
+      });
+    },
+    {
+      auditLog: {
+        operation: "DELETE_USER",
+        resourceType: "user",
+        getTargetId: ({ data }) => {
+          const result = data as { userId: string };
+          return result.userId;
+        },
+        getDetails: () => ({
           deleted: true,
-          userId: user.id,
-          email: user.email,
-        };
+        }),
       },
-    });
-  });
+    },
+  );
 }
 
-/**
- * Bulk delete users with per-item success/failure reporting.
- */
 export async function deleteUsersBulk(
   userIds: string[],
   idempotencyKey: string,
 ) {
-  return safeAction("deleteUsersBulk", async ({ adminUserId }) => {
-    await requireAdminGranularRole(USER_MUTATION_ROLES, adminUserId);
+  return safeAction(
+    "deleteUsersBulk",
+    async ({ actor, adminUserId }) => {
+      const parsedInput = parseActionInput(
+        DeleteUsersBulkSchema,
+        { userIds },
+        "No users selected",
+      );
+      const parsedIdempotencyKey = parseActionInput(
+        IdempotencyKeySchema,
+        idempotencyKey,
+        "Idempotency-Key is required",
+      );
 
-    return runWithIdempotency({
-      adminUserId,
-      actionName: "deleteUsersBulk",
-      idempotencyKey,
-      resourceId: userIds.slice().sort().join(","),
-      ttlHours: USER_IDEMPOTENCY_TTL_HOURS,
-      run: async () => {
-        const uniqueIds = Array.from(new Set(userIds.filter(Boolean)));
-        if (uniqueIds.length === 0) {
-          throw new Error("No users selected");
-        }
+      return runWithIdempotency({
+        adminUserId,
+        actionName: "deleteUsersBulk",
+        idempotencyKey: parsedIdempotencyKey,
+        resourceId: parsedInput.userIds.slice().sort().join(","),
+        ttlHours: USER_IDEMPOTENCY_TTL_HOURS,
+        run: async () => {
+          const batchResult = await usersService.prepareDeleteUsersBulk(actor, {
+            userIds: parsedInput.userIds,
+          });
 
-        if (uniqueIds.length > 50) {
-          throw new Error(
-            "Bulk delete limit exceeded (max 50 users per request)",
-          );
-        }
-
-        const client = await clerkClient();
-        const results: Array<{
-          userId: string;
-          success: boolean;
-          email?: string;
-          error?: string;
-        }> = [];
-
-        for (const userId of uniqueIds) {
-          if (userId === adminUserId) {
-            results.push({
-              userId,
-              success: false,
-              error: "Cannot delete your own admin account",
-            });
-            continue;
+          if (!batchResult.ok) {
+            throw new Error(batchResult.message);
           }
 
-          try {
-            const user = await prisma.user.findUnique({
-              where: { id: userId },
-              select: { id: true, clerkId: true, email: true },
-            });
+          const client = await clerkClient();
+          const results: Array<{
+            userId: string;
+            success: boolean;
+            email?: string;
+            error?: string;
+          }> = [];
 
-            if (!user) {
-              results.push({ userId, success: false, error: "User not found" });
+          for (const candidateId of batchResult.data.userIds) {
+            const deleteResult = await usersService.prepareDeleteUser(
+              actor,
+              candidateId,
+            );
+
+            if (!deleteResult.ok) {
+              results.push({
+                userId: candidateId,
+                success: false,
+                error: deleteResult.message,
+              });
               continue;
             }
 
+            const user = deleteResult.data;
+
             try {
               await client.users.deleteUser(user.clerkId);
-            } catch (clerkError: unknown) {
-              const error = clerkError as { status?: number };
-              if (error.status !== 404) {
-                throw new Error("Failed to remove user from identity provider");
-              }
+            } catch (error) {
+              buildClerkDeleteError(error);
             }
 
-            await prisma.user.delete({ where: { id: user.id } });
+            await usersRepository.deleteUserById(user.id);
             results.push({ userId: user.id, email: user.email, success: true });
-          } catch (error) {
-            results.push({
-              userId,
-              success: false,
-              error: error instanceof Error ? error.message : "Unknown error",
-            });
           }
-        }
 
-        const successful = results.filter((result) => result.success).length;
-        const failed = results.length - successful;
+          const successful = results.filter((result) => result.success).length;
+          const failed = results.length - successful;
 
-        await logAdminAction({
-          userId: adminUserId,
-          action: "BULK_DELETE_USERS",
-          targetType: "user",
-          targetId: "bulk",
-          details: {
-            total: results.length,
-            successful,
-            failed,
-          },
-        });
+          revalidatePath("/users");
 
-        revalidatePath("/users");
-
-        return {
-          summary: {
-            total: results.length,
-            successful,
-            failed,
-          },
-          results,
-        };
+          return {
+            summary: {
+              total: results.length,
+              successful,
+              failed,
+            },
+            results,
+          };
+        },
+      });
+    },
+    {
+      auditLog: {
+        operation: "BULK_DELETE_USERS",
+        resourceType: "user",
+        getTargetId: () => "bulk",
+        getDetails: ({ data }) => {
+          const result = data as {
+            summary: { total: number; successful: number; failed: number };
+          };
+          return result.summary;
+        },
       },
-    });
-  });
+    },
+  );
 }
 
-/**
- * Sends a Clerk invitation for a new user with the requested platform role.
- */
 export async function inviteUser(
   input: { email: string; role: string },
   idempotencyKey: string,
 ) {
-  return safeAction("inviteUser", async ({ adminUserId }) => {
-    await requireAdminGranularRole(USER_MUTATION_ROLES, adminUserId);
+  return safeAction(
+    "inviteUser",
+    async ({ actor, adminUserId }) => {
+      const parsedInput = parseActionInput(
+        InviteUserSchema,
+        input,
+        "Valid invitation payload is required",
+      );
+      const parsedIdempotencyKey = parseActionInput(
+        IdempotencyKeySchema,
+        idempotencyKey,
+        "Idempotency-Key is required",
+      );
 
-    return runWithIdempotency({
-      adminUserId,
-      actionName: "inviteUser",
-      idempotencyKey,
-      resourceId: input.email?.trim().toLowerCase(),
-      ttlHours: USER_IDEMPOTENCY_TTL_HOURS,
-      run: async () => {
-        const email = input.email?.trim().toLowerCase();
-        const role = normalizeUserRole(input.role || "");
+      return runWithIdempotency({
+        adminUserId,
+        actionName: "inviteUser",
+        idempotencyKey: parsedIdempotencyKey,
+        resourceId: parsedInput.email.trim().toLowerCase(),
+        ttlHours: USER_IDEMPOTENCY_TTL_HOURS,
+        run: async () => {
+          const result = await usersService.prepareInviteUser(actor, parsedInput);
 
-        if (!email || !email.includes("@")) {
-          throw new Error("Valid email is required");
-        }
+          if (!result.ok) {
+            throw new Error(result.message);
+          }
 
-        const existingUser = await prisma.user.findFirst({
-          where: { email: { equals: email, mode: "insensitive" } },
-          select: { id: true },
-        });
+          const client = await clerkClient();
+          const invitation = await client.invitations.createInvitation({
+            emailAddress: result.data.email,
+            publicMetadata: {
+              role: result.data.role,
+            },
+          });
 
-        if (existingUser) {
-          throw new Error("A user with this email already exists");
-        }
-
-        const client = await clerkClient();
-        const invitation = await client.invitations.createInvitation({
-          emailAddress: email,
-          publicMetadata: {
-            role,
-          },
-        });
-
-        await logAdminAction({
-          userId: adminUserId,
-          action: "INVITE_USER",
-          targetType: "user",
-          targetId: invitation.id || email,
-          details: {
-            email,
-            role,
+          return {
+            invited: true,
+            email: result.data.email,
+            role: result.data.role,
             invitationId: invitation.id || null,
-          },
-        });
-
-        return {
-          invited: true,
-          email,
-          role,
-          invitationId: invitation.id || null,
-        };
+          };
+        },
+      });
+    },
+    {
+      auditLog: {
+        operation: "INVITE_USER",
+        resourceType: "user",
+        getTargetId: ({ data }) => {
+          const result = data as { invitationId: string | null; email: string };
+          return result.invitationId ?? result.email;
+        },
+        getDetails: ({ data }) => {
+          const result = data as { role: string; invitationId: string | null };
+          return {
+            role: result.role,
+            invitationId: result.invitationId,
+          };
+        },
       },
-    });
-  });
+    },
+  );
 }
 
-/**
- * Forces a user to reset credentials on next login.
- */
 export async function resetUserCredentials(
   userId: string,
   idempotencyKey: string,
 ) {
-  return safeAction("resetUserCredentials", async ({ adminUserId }) => {
-    await requireAdminGranularRole(USER_MUTATION_ROLES, adminUserId);
+  return safeAction(
+    "resetUserCredentials",
+    async ({ actor, adminUserId }) => {
+      const parsedUserId = parseActionInput(
+        NonEmptyStringSchema,
+        userId,
+        "User ID is required",
+      );
+      const parsedIdempotencyKey = parseActionInput(
+        IdempotencyKeySchema,
+        idempotencyKey,
+        "Idempotency-Key is required",
+      );
 
-    return runWithIdempotency({
-      adminUserId,
-      actionName: "resetUserCredentials",
-      idempotencyKey,
-      resourceId: userId,
-      ttlHours: USER_IDEMPOTENCY_TTL_HOURS,
-      run: async () => {
-        const user = await prisma.user.findUnique({
-          where: { id: userId },
-          select: {
-            id: true,
-            clerkId: true,
-            email: true,
-            passwordResetRequired: true,
-          },
-        });
+      return runWithIdempotency({
+        adminUserId,
+        actionName: "resetUserCredentials",
+        idempotencyKey: parsedIdempotencyKey,
+        resourceId: parsedUserId,
+        ttlHours: USER_IDEMPOTENCY_TTL_HOURS,
+        run: async () => {
+          const result = await usersService.prepareResetUserCredentials(
+            actor,
+            parsedUserId,
+          );
 
-        if (!user) {
-          throw new Error("User not found");
-        }
+          if (!result.ok) {
+            throw new Error(result.message);
+          }
 
-        const client = await clerkClient();
-        await client.users.updateUserMetadata(user.clerkId, {
-          publicMetadata: {
-            passwordResetRequired: true,
-          },
-        });
+          const user = result.data;
+          const client = await clerkClient();
 
-        await prisma.user.update({
-          where: { id: user.id },
-          data: {
-            passwordResetRequired: true,
-          },
-        });
+          await client.users.updateUserMetadata(user.clerkId, {
+            publicMetadata: {
+              passwordResetRequired: true,
+            },
+          });
 
-        await logAdminAction({
-          userId: adminUserId,
-          action: "RESET_USER_CREDENTIALS",
-          targetType: "user",
-          targetId: user.id,
-          details: {
+          await usersRepository.markPasswordResetRequired(user.id);
+
+          revalidatePath("/users");
+          revalidatePath(`/users/${user.id}`);
+
+          return {
+            updated: true,
+            userId: user.id,
             email: user.email,
-            previouslyRequired: user.passwordResetRequired,
-            nowRequired: true,
-          },
-        });
-
-        revalidatePath("/users");
-        revalidatePath(`/users/${user.id}`);
-
-        return {
-          updated: true,
-          userId: user.id,
-          email: user.email,
+            passwordResetRequired: true,
+          };
+        },
+      });
+    },
+    {
+      auditLog: {
+        operation: "RESET_USER_CREDENTIALS",
+        resourceType: "user",
+        getTargetId: ({ data }) => {
+          const result = data as { userId: string };
+          return result.userId;
+        },
+        getDetails: () => ({
           passwordResetRequired: true,
-        };
+        }),
       },
-    });
-  });
+    },
+  );
 }
 
-/**
- * Assigns a new platform role to an existing user.
- */
 export async function assignUserRole(
   userId: string,
   roleInput: string,
   idempotencyKey: string,
 ) {
-  return safeAction("assignUserRole", async ({ adminUserId }) => {
-    await requireAdminGranularRole(USER_MUTATION_ROLES, adminUserId);
+  return safeAction(
+    "assignUserRole",
+    async ({ actor, adminUserId }) => {
+      const parsedInput = parseActionInput(
+        AssignUserRoleSchema,
+        { userId, role: roleInput },
+        "Valid role assignment payload is required",
+      );
+      const parsedIdempotencyKey = parseActionInput(
+        IdempotencyKeySchema,
+        idempotencyKey,
+        "Idempotency-Key is required",
+      );
 
-    return runWithIdempotency({
-      adminUserId,
-      actionName: "assignUserRole",
-      idempotencyKey,
-      resourceId: userId,
-      ttlHours: USER_IDEMPOTENCY_TTL_HOURS,
-      run: async () => {
-        const newRole = normalizeUserRole(roleInput || "");
+      return runWithIdempotency({
+        adminUserId,
+        actionName: "assignUserRole",
+        idempotencyKey: parsedIdempotencyKey,
+        resourceId: parsedInput.userId,
+        ttlHours: USER_IDEMPOTENCY_TTL_HOURS,
+        run: async () => {
+          const result = await usersService.prepareAssignUserRole(actor, parsedInput);
 
-        const user = await prisma.user.findUnique({
-          where: { id: userId },
-          select: { id: true, email: true, role: true, clerkId: true },
-        });
+          if (!result.ok) {
+            throw new Error(result.message);
+          }
 
-        if (!user) {
-          throw new Error("User not found");
-        }
+          const {
+            user,
+            role,
+          } = result.data;
 
-        if (user.id === adminUserId && newRole !== "ADMIN") {
-          throw new Error("Cannot remove your own admin platform role");
-        }
+          await usersRepository.updateUserRole(user.id, role);
 
-        await prisma.user.update({
-          where: { id: user.id },
-          data: {
-            role: newRole,
-          },
-        });
+          const client = await clerkClient();
+          await client.users.updateUserMetadata(user.clerkId, {
+            publicMetadata: {
+              role,
+            },
+          });
 
-        const client = await clerkClient();
-        await client.users.updateUserMetadata(user.clerkId, {
-          publicMetadata: {
-            role: newRole,
-          },
-        });
+          revalidatePath("/users");
+          revalidatePath(`/users/${user.id}`);
 
-        await logAdminAction({
-          userId: adminUserId,
-          action: "ASSIGN_USER_ROLE",
-          targetType: "user",
-          targetId: user.id,
-          details: {
+          return {
+            updated: true,
+            userId: user.id,
             email: user.email,
             previousRole: user.role,
-            newRole,
-          },
-        });
-
-        revalidatePath("/users");
-        revalidatePath(`/users/${user.id}`);
-
-        return {
-          updated: true,
-          userId: user.id,
-          email: user.email,
-          previousRole: user.role,
-          newRole,
-        };
+            newRole: role,
+          };
+        },
+      });
+    },
+    {
+      auditLog: {
+        operation: "ASSIGN_USER_ROLE",
+        resourceType: "user",
+        getTargetId: ({ data }) => {
+          const result = data as { userId: string };
+          return result.userId;
+        },
+        getDetails: ({ data }) => {
+          const result = data as { previousRole: string; newRole: string };
+          return {
+            previousRole: result.previousRole,
+            newRole: result.newRole,
+          };
+        },
       },
-    });
-  });
+    },
+  );
 }

--- a/apps/admin/src/lib/domains/users/__tests__/service.test.ts
+++ b/apps/admin/src/lib/domains/users/__tests__/service.test.ts
@@ -15,6 +15,9 @@ const repositoryMock = vi.hoisted(() => ({
   countUsers: vi.fn(),
   findUserDetailsById: vi.fn(),
   findUserByEmail: vi.fn(),
+  findUserRoleTarget: vi.fn(),
+  findUserIdentityTarget: vi.fn(),
+  findUserCredentialsTarget: vi.fn(),
 }));
 
 vi.mock("@build/db", () => ({
@@ -29,7 +32,10 @@ import {
   getAdminUserDetails,
   listAdminUsers,
   prepareAssignUserRole,
+  prepareDeleteUser,
+  prepareDeleteUsersBulk,
   prepareInviteUser,
+  prepareResetUserCredentials,
 } from "../service";
 
 function actor(
@@ -165,6 +171,114 @@ describe("users domain service", () => {
       ok: false,
       error: "SELF_ROLE_CHANGE_DENIED",
       message: "Cannot remove your own admin platform role",
+    });
+  });
+
+  it("loads the target user during role assignment preparation", async () => {
+    repositoryMock.findUserRoleTarget.mockResolvedValue({
+      id: "user_1",
+      email: "user@example.com",
+      role: "CLIENT",
+      clerkId: "clerk_1",
+    });
+
+    const result = await prepareAssignUserRole(
+      actor(dbMock.AdminRole.SUPER_ADMIN),
+      {
+        userId: "user_1",
+        role: "professional",
+      },
+    );
+
+    expect(result).toEqual({
+      ok: true,
+      data: {
+        user: {
+          id: "user_1",
+          email: "user@example.com",
+          role: "CLIENT",
+          clerkId: "clerk_1",
+        },
+        role: "PROFESSIONAL",
+      },
+    });
+  });
+
+  it("prevents self-deletion and missing targets during delete preparation", async () => {
+    const selfDelete = await prepareDeleteUser(
+      actor(dbMock.AdminRole.SUPER_ADMIN),
+      "admin_1",
+    );
+
+    expect(selfDelete).toEqual({
+      ok: false,
+      error: "SELF_DELETE_DENIED",
+      message: "Cannot delete your own admin account",
+    });
+
+    repositoryMock.findUserIdentityTarget.mockResolvedValue(null);
+    const missing = await prepareDeleteUser(
+      actor(dbMock.AdminRole.SUPER_ADMIN),
+      "user_404",
+    );
+
+    expect(missing).toEqual({
+      ok: false,
+      error: "USER_NOT_FOUND",
+      message: "User not found",
+    });
+  });
+
+  it("normalizes and bounds bulk delete input", async () => {
+    const result = await prepareDeleteUsersBulk(
+      actor(dbMock.AdminRole.SUPER_ADMIN),
+      {
+        userIds: [" user_1 ", "user_2", "user_1", ""],
+      },
+    );
+
+    expect(result).toEqual({
+      ok: true,
+      data: {
+        userIds: ["user_1", "user_2"],
+      },
+    });
+
+    const tooMany = await prepareDeleteUsersBulk(
+      actor(dbMock.AdminRole.SUPER_ADMIN),
+      {
+        userIds: Array.from({ length: 51 }, (_, index) => `user_${index}`),
+      },
+    );
+
+    expect(tooMany).toEqual({
+      ok: false,
+      error: "BULK_LIMIT_EXCEEDED",
+      message: "Bulk delete limit exceeded (max 50 users per request)",
+    });
+  });
+
+  it("returns credentials target for reset preparation", async () => {
+    repositoryMock.findUserCredentialsTarget.mockResolvedValue({
+      id: "user_1",
+      clerkId: "clerk_1",
+      email: "user@example.com",
+      passwordResetRequired: false,
+    });
+
+    const result = await prepareResetUserCredentials(
+      actor(dbMock.AdminRole.SUPER_ADMIN),
+      "user_1",
+    );
+
+    expect(result).toEqual({
+      ok: true,
+      data: {
+        id: "user_1",
+        clerkId: "clerk_1",
+        email: "user@example.com",
+        passwordResetRequired: false,
+      },
     });
   });
 });

--- a/apps/admin/src/lib/domains/users/contracts.ts
+++ b/apps/admin/src/lib/domains/users/contracts.ts
@@ -10,6 +10,9 @@ export type UsersDomainErrorCode =
   | "USER_NOT_FOUND"
   | "USER_ALREADY_EXISTS"
   | "SELF_ROLE_CHANGE_DENIED"
+  | "SELF_DELETE_DENIED"
+  | "USER_SELECTION_REQUIRED"
+  | "BULK_LIMIT_EXCEEDED"
   | "REPOSITORY_ERROR";
 
 export type UsersDomainError = {
@@ -97,8 +100,12 @@ export type AssignUserRoleInput = {
 };
 
 export type NormalizedAssignUserRoleInput = {
-  userId: string;
+  user: UserRoleTarget;
   role: AssignableUserRole;
+};
+
+export type DeleteUsersBulkInput = {
+  userIds: string[];
 };
 
 export type UsersAuthorizationSnapshot = {

--- a/apps/admin/src/lib/domains/users/service.ts
+++ b/apps/admin/src/lib/domains/users/service.ts
@@ -11,6 +11,7 @@ import {
 import type {
   AdminUserDetails,
   AdminUserActor,
+  DeleteUsersBulkInput,
   AssignUserRoleInput,
   InviteUserInput,
   ListUsersInput,
@@ -19,6 +20,8 @@ import type {
   NormalizedAssignUserRoleInput,
   NormalizedInviteUserInput,
   UsersDomainError,
+  UserCredentialsTarget,
+  UserIdentityTarget,
 } from "./contracts";
 import * as repository from "./repository";
 
@@ -226,5 +229,106 @@ export async function prepareAssignUserRole(
     });
   }
 
-  return ok({ userId: input.userId, role: roleResult.data });
+  try {
+    const user = await repository.findUserRoleTarget(input.userId);
+
+    if (!user) {
+      return err({ error: "USER_NOT_FOUND", message: "User not found" });
+    }
+
+    return ok({ user, role: roleResult.data });
+  } catch (error) {
+    return err(toDomainError(error));
+  }
+}
+
+export async function prepareDeleteUser(
+  actor: AdminUserActor,
+  userId: string,
+): Promise<Result<UserIdentityTarget, UsersDomainError>> {
+  const authResult = requireManageUsers(actor);
+
+  if (!authResult.ok) {
+    return authResult;
+  }
+
+  if (!userId.trim()) {
+    return err({ error: "INVALID_INPUT", message: "User ID is required" });
+  }
+
+  if (userId === actor.dbUserId) {
+    return err({
+      error: "SELF_DELETE_DENIED",
+      message: "Cannot delete your own admin account",
+    });
+  }
+
+  try {
+    const user = await repository.findUserIdentityTarget(userId);
+
+    if (!user) {
+      return err({ error: "USER_NOT_FOUND", message: "User not found" });
+    }
+
+    return ok(user);
+  } catch (error) {
+    return err(toDomainError(error));
+  }
+}
+
+export async function prepareDeleteUsersBulk(
+  actor: AdminUserActor,
+  input: DeleteUsersBulkInput,
+): Promise<Result<{ userIds: string[] }, UsersDomainError>> {
+  const authResult = requireManageUsers(actor);
+
+  if (!authResult.ok) {
+    return authResult;
+  }
+
+  const userIds = Array.from(new Set(input.userIds.map((userId) => userId.trim())))
+    .filter(Boolean);
+
+  if (userIds.length === 0) {
+    return err({
+      error: "USER_SELECTION_REQUIRED",
+      message: "No users selected",
+    });
+  }
+
+  if (userIds.length > 50) {
+    return err({
+      error: "BULK_LIMIT_EXCEEDED",
+      message: "Bulk delete limit exceeded (max 50 users per request)",
+    });
+  }
+
+  return ok({ userIds });
+}
+
+export async function prepareResetUserCredentials(
+  actor: AdminUserActor,
+  userId: string,
+): Promise<Result<UserCredentialsTarget, UsersDomainError>> {
+  const authResult = requireManageUsers(actor);
+
+  if (!authResult.ok) {
+    return authResult;
+  }
+
+  if (!userId.trim()) {
+    return err({ error: "INVALID_INPUT", message: "User ID is required" });
+  }
+
+  try {
+    const user = await repository.findUserCredentialsTarget(userId);
+
+    if (!user) {
+      return err({ error: "USER_NOT_FOUND", message: "User not found" });
+    }
+
+    return ok(user);
+  } catch (error) {
+    return err(toDomainError(error));
+  }
 }


### PR DESCRIPTION
### Phase: 5 - Users action slice

- Added `safeParse`-backed input validation for admin user detail, delete, bulk delete, invite, reset-credentials, and role-assignment actions.
- Added declarative `auditLog` coverage in `safeAction` so high-risk user mutations can attach target IDs and non-PII details without manual audit calls.
- Blocked self-deletion for admin user mutations to align single-delete behavior with the existing bulk-delete guard.

### Changed (Phase 5 - Users action slice)

- Removed direct Prisma access from `apps/admin/src/actions/admin/users.ts`; the action slice now delegates persistence to `usersRepository` and business rules to `usersService`.
- Moved remaining users mutation preconditions into the users domain service, including target lookups, bulk-delete normalization, and reset/role-assignment preparation.
- Updated the admin security drift reporter so declarative `auditLog:` usage counts as audit coverage for high-risk action files.

### Tests (Phase 5 - Users action slice)

- Reworked users action-boundary tests to assert service/repository delegation instead of action-layer Prisma calls.
- Extended users domain service tests for delete preparation, bulk-delete normalization, reset preparation, and role-assignment target loading.

**Verification:**

- `pnpm run admin:check-types` -> pass.
- `pnpm run admin:lint` -> pass with 211 warnings; warnings remain tracked Phase 5-12 backlog.
- `pnpm run admin:check-env-contract` -> pass; all env templates cover 59 boundary keys.
- `pnpm run admin:test:all` -> pass; 26 files passed, 174 of 174 tests passed.
- `pnpm -C apps/admin exec vitest run src/lib/domains/users/__tests__/service.test.ts src/lib/domains/users/__tests__/repository.test.ts src/actions/admin/__tests__/users-actions.test.ts --pool=threads --maxWorkers=1` -> pass; 3 files passed, 22 of 22 tests passed.
- `pnpm run admin:report-security-drift` -> pass with known drift counts: env boundary 69, direct Prisma action files 17, unsafe mutations 13, action `.parse()` 23, `@ts-nocheck` 21, unstructured logging 103, log safety 3, missing audit log 3.
- `pnpm run admin:report-security-drift:strict` -> fail with the remaining Phase 5-12 drift backlog.