### PR TITLE
feat(admin-overhaul): add Phase 7 observability foundation

### DIFF
--- a/apps/admin/docs/CHANGELOG.md
+++ b/apps/admin/docs/CHANGELOG.md
@@ -1,6 +1,36 @@
 # apps/admin Changelog
 
-## [2026-05-21] Phase 5 - Verification action bug fixes
+## [2026-05-21] Phase 7 - Observability foundation
+
+### Added (Phase 7 - Observability foundation)
+
+- Added `src/lib/infrastructure/logger.ts` implementing ADR-ADMIN-003: `getAdminLogger()` returns a feature-flag-gated structured logger with PII exclusion enforced at the type level (keys `userId`, `email`, `phone`, `nationalId`, `clerkId`, `userEmail`, `adminEmail`, `userPhone`, `firstName`, `lastName` are rejected). Structured mode writes JSON to stdout; fallback mode delegates to `console.log/warn/error` when `admin_v2_structured_logging` is disabled.
+- Added `src/lib/infrastructure/correlation.ts` implementing ADR-ADMIN-003 §7.2: `initializeAdminCorrelationId()` reads `x-correlation-id` from request headers or generates UUID v4; `withAdminCorrelation()` threads the ID through async continuations via `AsyncLocalStorage`; `getAdminCorrelationId()` reads the active ID without prop-drilling.
+- Added `src/lib/observability/operation-names.ts` implementing ADR-ADMIN-003 §7.3: typed `AdminOperationName` const registry with 40+ stable `<verb>_<resource>` operation names covering users, verification, audit, finance, content, leads/services, compliance, settings, and dashboard. Added `isRegisteredOperationName()` guard for drift-check use.
+
+### Changed (Phase 7 - Observability foundation)
+
+- Integrated structured logger into `safeAction` and `safeVerificationAction` in `shared.ts`: every terminal outcome path (unauthorized, forbidden, session_stale, rate_limited, success, internal_error) now emits a structured `AdminLogEvent` with `correlationId`, `operationName`, `adminRole`, `outcome`, and `durationMs`.
+- `safeAction` now wraps action body execution in `withAdminCorrelation()` so downstream service/repository code can call `getAdminCorrelationId()` without receiving the ID via parameter.
+- `correlationId` in the action context is now sourced from a single `crypto.randomUUID()` call at the top of `safeAction`, shared across the log emission and the action body context.
+
+### Tests (Phase 7 - Observability foundation)
+
+- Added `src/lib/infrastructure/__tests__/logger.test.ts` (11 tests): structured-mode JSON output, PII runtime stripping, optional field omission, all log levels, fallback-mode console routing.
+- Added `src/lib/infrastructure/__tests__/correlation.test.ts` (11 tests): header extraction, UUID generation, blank-header guard, uniqueness, async propagation, scope isolation, concurrent scope independence, outside-scope undefined return.
+- Added `src/lib/observability/__tests__/operation-names.test.ts` (14 tests): lower_snake_case enforcement, uniqueness, verb_resource format, domain coverage assertions, type assignability, `isRegisteredOperationName` guard.
+
+**Files changed:** `apps/admin/src/lib/infrastructure/logger.ts` [NEW], `apps/admin/src/lib/infrastructure/correlation.ts` [NEW], `apps/admin/src/lib/observability/operation-names.ts` [NEW], `apps/admin/src/lib/infrastructure/__tests__/logger.test.ts` [NEW], `apps/admin/src/lib/infrastructure/__tests__/correlation.test.ts` [NEW], `apps/admin/src/lib/observability/__tests__/operation-names.test.ts` [NEW], `apps/admin/src/actions/admin/shared.ts`
+
+**Verification:**
+
+- `pnpm run admin:check-types` → pass.
+- `pnpm run admin:lint` → pass with known warnings backlog.
+- `pnpm run admin:check-env-contract` → pass; 59 boundary keys.
+- `pnpm run admin:test:all` → pass; 29 files passed, 213 of 213 tests passed.
+- Targeted suite: `pnpm -C apps/admin exec vitest run src/lib/infrastructure/__tests__/logger.test.ts src/lib/infrastructure/__tests__/correlation.test.ts src/lib/observability/__tests__/operation-names.test.ts --pool=threads --maxWorkers=1` → 3 files, 36 tests passed.
+
+
 
 ### Fixed (Phase 5 - Verification action bug fixes)
 

--- a/apps/admin/docs/PROGRESS-SUMMARY.md
+++ b/apps/admin/docs/PROGRESS-SUMMARY.md
@@ -4,8 +4,8 @@
 
 ## Active Phase
 
-**Phase:** Phase 5 - Verification action slice
-**Status:** Implemented on `feat/admin-overhaul/actions-verification`, stacked on the unmerged `feat/admin-overhaul/actions-users` Phase 5 baseline after the Phase 4 integration tag `admin-overhaul/phase-4-complete`.
+**Phase:** Track C Phase 7 - Observability foundation (complete) / Track A Phase 5 - Audit/export action slice (next)
+**Status:** Track C implemented on `feat/admin-overhaul/observability`, ready for PR to `integration/admin-overhaul`. Track B `feat/admin-overhaul/ui-tokens` (tokens + route boundaries) runs in parallel with Track A.
 
 **Completed:**
 
@@ -23,15 +23,15 @@
 - Phase 5 users action slice added: `safeParse` action validation, service/repository delegation for all user mutations, declarative audit coverage, self-delete protection, and refreshed users action-boundary tests.
 - Phase 5 verification action slice added: `safeAction` migration, verification service-backed queue/stats/details/mutation adapters, normalized document verification contracts, updated verification route handlers, and refreshed action/route/domain tests.
 - Phase 5 verification bug fixes applied: fixed API route audit gaps, privilege escalation fallbacks, unhandled parsing exceptions, and string concatenation bugs.
+- Phase 5 users and verification PRs merged; tag `admin-overhaul/phase-5-complete` pushed.
+- Phase 7 (Track C) observability foundation added on `feat/admin-overhaul/observability`: structured `getAdminLogger()` with PII exclusion, `AsyncLocalStorage`-backed correlation ID threading, typed `AdminOperationName` registry (40+ operations), and `safeAction`/`safeVerificationAction` integration emitting structured log events at every outcome path.
 
 **Remaining steps:**
 
-- Open and merge the Phase 5 users action PR from `feat/admin-overhaul/actions-users` into `integration/admin-overhaul`.
-- Open and merge the Phase 5 verification action PR from `feat/admin-overhaul/actions-verification`, stacked on the users slice baseline.
-- Start Track C Phase 7 observability on a separate branch after the users slice is stable enough to consume the improved audit/logger primitives.
-- Continue Track A with the audit/export slice so direct Prisma and `.parse()` drift drop in the remaining high-risk export/compliance readers and mutations.
-- Start Track B Phase 6 token and route-boundary work after the current action slice lands, keeping UI-only changes isolated from Track A.
-- Continue reducing lint/security-drift warnings inside the active action/security slices instead of deferring new debt.
+- Merge Track C `feat/admin-overhaul/observability` PR into `integration/admin-overhaul`; apply `admin-overhaul/phase-7-complete` tag.
+- Start Track A `feat/admin-overhaul/actions-audit`: migrate `audit.ts` and `compliance/route.ts` off direct Prisma / `.parse()` / `@ts-nocheck`, consuming the Phase 7 structured logger. Fix `professionals.ts` log-safety drift.
+- Start Track B `feat/admin-overhaul/ui-tokens` in parallel: create `tokens.css`, import in `globals.css`, add `loading.tsx`/`error.tsx` for 5 route segments, adopt tokens in `CardList.tsx`, `AppBarChart.tsx`, `AddUser.tsx`.
+- Continue reducing remaining drift: 13 direct-Prisma action files, 16 `.parse()` call sites, 12 unsafe mutations, 18 `@ts-nocheck` files.
 
 ## Slice Status Registry
 
@@ -75,13 +75,13 @@ pnpm -C apps/admin exec vitest run --pool=threads --maxWorkers=1
 
 ## Latest Verification
 
-- `pnpm run admin:check-types` -> pass.
-- `pnpm run admin:lint` -> pass with 156 warnings.
-- `pnpm run admin:check-env-contract` -> pass; all env templates cover 59 boundary keys.
-- `pnpm run admin:report-security-drift` -> pass with known drift counts: env boundary 69, direct Prisma action files 13, unsafe mutations 12, action `.parse()` 16, `@ts-nocheck` 18, unstructured logging 103, log safety 3, missing audit log 3.
-- `pnpm run admin:report-security-drift:strict` -> fail with known Phase 4-12 drift backlog.
-- `pnpm run admin:test:all` -> pass; 26 files passed, 177 of 177 tests passed.
-- `pnpm -C apps/admin exec vitest run src/lib/domains/verification/__tests__/service.test.ts src/actions/admin/__tests__/verification-actions.test.ts __tests__/admin-verification/verify-api.test.ts __tests__/admin-verification/verify-document-api.test.ts --pool=threads --maxWorkers=1` -> pass; 4 files passed, 26 of 26 tests passed.
+- `pnpm run admin:check-types` → pass.
+- `pnpm run admin:lint` → pass with known warnings backlog.
+- `pnpm run admin:check-env-contract` → pass; 59 boundary keys.
+- `pnpm run admin:report-security-drift` → pass with known drift counts: env boundary 69, direct Prisma action files 13, unsafe mutations 12, action `.parse()` 16, `@ts-nocheck` 18, unstructured logging 103, log safety 3, missing audit log 2.
+- `pnpm run admin:report-security-drift:strict` → fail with known Phase 4-12 drift backlog.
+- `pnpm run admin:test:all` → pass; 29 files passed, 213 of 213 tests passed.
+- `pnpm -C apps/admin exec vitest run src/lib/infrastructure/__tests__/logger.test.ts src/lib/infrastructure/__tests__/correlation.test.ts src/lib/observability/__tests__/operation-names.test.ts --pool=threads --maxWorkers=1` → 3 files, 36 tests passed.
 
 ## Completed Phases
 
@@ -91,8 +91,9 @@ pnpm -C apps/admin exec vitest run --pool=threads --maxWorkers=1
 4. Phase 3 Auth Hardening - completed 2026-05-18; checkpoint tag `admin-overhaul/phase-3-complete`.
 5. Phase 10 Feature Flags - completed 2026-05-18; checkpoint tag `admin-overhaul/phase-10-complete`.
 6. Phase 4 Domain/Repository Layer - completed 2026-05-18; checkpoint tag `admin-overhaul/phase-4-complete`.
-7. Phase 5 Users Action Slice - implemented 2026-05-18 on `feat/admin-overhaul/actions-users`; pending PR merge.
-8. Phase 5 Verification Action Slice - implemented 2026-05-18 on `feat/admin-overhaul/actions-verification`; pending PR merge and follow-on action slices for audit/export, finance, content, and leads/services/professionals.
+7. Phase 5 Users Action Slice - merged 2026-05-21; checkpoint tag `admin-overhaul/phase-5-complete`.
+8. Phase 5 Verification Action Slice - merged 2026-05-21; pending follow-on action slices for audit/export, finance, content, and leads/services/professionals.
+9. Phase 7 (Track C) Observability Foundation - implemented 2026-05-21 on `feat/admin-overhaul/observability`; pending PR merge. Structured logger, correlation threading, operation name registry, `safeAction` integration.
 
 ## Rollback Contracts
 
@@ -108,4 +109,4 @@ Phase 10 flags are runtime-readable through `adminEnvConfig`; toggling them requ
 
 ## Next Priority
 
-Continue Phase 5 on the audit/GDPR/export slice after merging the stacked users and verification action branches, then sequence finance/analytics, stores/properties/projects, and leads/services/professionals.
+Merge Track C `feat/admin-overhaul/observability` PR. Then open Track A `feat/admin-overhaul/actions-audit` to migrate `audit.ts` and `compliance/route.ts` off direct Prisma and `.parse()`, consuming the Phase 7 logger. Open Track B `feat/admin-overhaul/ui-tokens` in parallel for the token system and route-boundary work. After Track A merges, continue with `finance/analytics`, `stores/properties/projects`, and `leads/services/professionals` action slices.

--- a/apps/admin/src/actions/admin/shared.ts
+++ b/apps/admin/src/actions/admin/shared.ts
@@ -21,6 +21,11 @@ import { checkRateLimit } from "@/lib/api/rate-limit";
 import type { ActionResponse, AdminActionError } from "./types";
 import { adminEnvConfig } from "@/lib/infrastructure/env";
 import { omitUndefined } from "@/lib/utils";
+import {
+  getAdminLogger,
+  type AdminLogOutcome,
+} from "@/lib/infrastructure/logger";
+import { withAdminCorrelation } from "@/lib/infrastructure/correlation";
 
 export type {
   ActionResponse,
@@ -427,21 +432,44 @@ export async function safeAction<T>(
   options?: SafeActionOptions,
 ): Promise<ActionResponse<T>> {
   const timestamp = new Date().toISOString();
+  const requestStartedAt = Date.now();
+  const correlationId = crypto.randomUUID();
+  const logger = getAdminLogger();
+
+  function emitLog(
+    outcome: AdminLogOutcome,
+    adminRole: string,
+    extra?: { errorCode?: string; errorMessage?: string },
+  ): void {
+    logger.info({
+      correlationId,
+      operationName: actionName,
+      adminRole,
+      outcome,
+      durationMs: Date.now() - requestStartedAt,
+      ...omitUndefined(extra ?? {}),
+    });
+  }
 
   try {
     const actorResult = await resolveAdminActor();
 
     if (!actorResult.success) {
+      emitLog("unauthorized", "unknown", {
+        errorCode: actorResult.error.code,
+      });
       return adminActionFailure(
         { ...actorResult.error, action: actionName },
         timestamp,
       );
     }
 
+    const adminRole = String(actorResult.actor.adminRole);
     const policy = getAdminActionPolicy(actionName);
     const actionOptions = mergeSafeActionOptions(policy, options);
 
     if (!policy.allowedRoles.includes(actorResult.actor.adminRole)) {
+      emitLog("forbidden", adminRole, { errorCode: "FORBIDDEN" });
       return adminActionFailure(
         adminActionError("FORBIDDEN", "Admin action policy denied", actionName),
         timestamp,
@@ -454,6 +482,7 @@ export async function safeAction<T>(
         capability,
       );
       if (!capabilityResult.success) {
+        emitLog("forbidden", adminRole, { errorCode: "FORBIDDEN" });
         return adminActionFailure(
           adminActionError(
             "FORBIDDEN",
@@ -471,6 +500,7 @@ export async function safeAction<T>(
       actionOptions.recentAuth,
     );
     if (staleSessionError) {
+      emitLog("session_stale", adminRole, { errorCode: "SESSION_STALE" });
       return adminActionFailure(staleSessionError, timestamp);
     }
 
@@ -480,16 +510,19 @@ export async function safeAction<T>(
       actionOptions.rateLimit,
     );
     if (rateLimitError) {
+      emitLog("rate_limited", adminRole, { errorCode: "RATE_LIMITED" });
       return adminActionFailure(rateLimitError, timestamp);
     }
 
-    const data = await fn({
-      actor: actorResult.actor,
-      adminUserId: actorResult.actor.dbUserId,
-      adminRole: actorResult.actor.adminRole,
-      correlationId: crypto.randomUUID(),
-      requestStartedAt: Date.now(),
-    });
+    const data = await withAdminCorrelation(correlationId, () =>
+      fn({
+        actor: actorResult.actor,
+        adminUserId: actorResult.actor.dbUserId,
+        adminRole: actorResult.actor.adminRole,
+        correlationId,
+        requestStartedAt,
+      }),
+    );
 
     await recordDeclarativeAudit(
       actorResult.actor,
@@ -497,6 +530,7 @@ export async function safeAction<T>(
       data,
     );
 
+    emitLog("success", adminRole);
     return {
       success: true,
       data,
@@ -505,6 +539,17 @@ export async function safeAction<T>(
   } catch (error) {
     const message =
       error instanceof Error ? error.message : "Admin action failed";
+
+    // Best-effort log — actor role may not be resolved at this point
+    logger.error({
+      correlationId,
+      operationName: actionName,
+      adminRole: "unknown",
+      outcome: "internal_error",
+      durationMs: Date.now() - requestStartedAt,
+      errorCode: "ACTION_FAILED",
+      errorMessage: message,
+    });
 
     return adminActionFailure(
       adminActionError("ACTION_FAILED", message, actionName),
@@ -525,21 +570,42 @@ export async function safeVerificationAction<T>(
   options?: SafeActionOptions,
 ): Promise<ActionResponse<T>> {
   const timestamp = new Date().toISOString();
+  const requestStartedAt = Date.now();
+  const correlationId = crypto.randomUUID();
+  const logger = getAdminLogger();
+
+  function emitLog(
+    outcome: AdminLogOutcome,
+    adminRole: string,
+    extra?: { errorCode?: string; errorMessage?: string },
+  ): void {
+    logger.info({
+      correlationId,
+      operationName: actionName,
+      adminRole,
+      outcome,
+      durationMs: Date.now() - requestStartedAt,
+      ...omitUndefined(extra ?? {}),
+    });
+  }
 
   try {
     const actorResult = await resolveAdminActor();
 
     if (!actorResult.success) {
+      emitLog("unauthorized", "unknown", { errorCode: actorResult.error.code });
       return adminActionFailure(
         { ...actorResult.error, action: actionName },
         timestamp,
       );
     }
 
+    const adminRole = String(actorResult.actor.adminRole);
     const policy = getAdminActionPolicy(actionName);
     const actionOptions = mergeSafeActionOptions(policy, options);
 
     if (!policy.allowedRoles.includes(actorResult.actor.adminRole)) {
+      emitLog("forbidden", adminRole, { errorCode: "FORBIDDEN" });
       return adminActionFailure(
         adminActionError("FORBIDDEN", "Admin action policy denied", actionName),
         timestamp,
@@ -552,6 +618,7 @@ export async function safeVerificationAction<T>(
       actionOptions.recentAuth,
     );
     if (staleSessionError) {
+      emitLog("session_stale", adminRole, { errorCode: "SESSION_STALE" });
       return adminActionFailure(staleSessionError, timestamp);
     }
 
@@ -561,16 +628,19 @@ export async function safeVerificationAction<T>(
       actionOptions.rateLimit,
     );
     if (rateLimitError) {
+      emitLog("rate_limited", adminRole, { errorCode: "RATE_LIMITED" });
       return adminActionFailure(rateLimitError, timestamp);
     }
 
-    const data = await fn({
-      actor: actorResult.actor,
-      adminUserId: actorResult.actor.dbUserId,
-      adminRole: actorResult.actor.adminRole,
-      correlationId: crypto.randomUUID(),
-      requestStartedAt: Date.now(),
-    });
+    const data = await withAdminCorrelation(correlationId, () =>
+      fn({
+        actor: actorResult.actor,
+        adminUserId: actorResult.actor.dbUserId,
+        adminRole: actorResult.actor.adminRole,
+        correlationId,
+        requestStartedAt,
+      }),
+    );
 
     await recordDeclarativeAudit(
       actorResult.actor,
@@ -578,6 +648,7 @@ export async function safeVerificationAction<T>(
       data,
     );
 
+    emitLog("success", adminRole);
     return {
       success: true,
       data,
@@ -586,6 +657,16 @@ export async function safeVerificationAction<T>(
   } catch (error) {
     const message =
       error instanceof Error ? error.message : "Admin action failed";
+
+    logger.error({
+      correlationId,
+      operationName: actionName,
+      adminRole: "unknown",
+      outcome: "internal_error",
+      durationMs: Date.now() - requestStartedAt,
+      errorCode: "ACTION_FAILED",
+      errorMessage: message,
+    });
 
     return adminActionFailure(
       adminActionError("ACTION_FAILED", message, actionName),

--- a/apps/admin/src/lib/infrastructure/__tests__/correlation.test.ts
+++ b/apps/admin/src/lib/infrastructure/__tests__/correlation.test.ts
@@ -1,0 +1,130 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import {
+  initializeAdminCorrelationId,
+  withAdminCorrelation,
+  getAdminCorrelationId,
+} from "../correlation";
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+// ---------------------------------------------------------------------------
+// initializeAdminCorrelationId
+// ---------------------------------------------------------------------------
+
+describe("initializeAdminCorrelationId", () => {
+  it("reads x-correlation-id from request headers when present", () => {
+    const request = new Request("https://example.com", {
+      headers: { "x-correlation-id": "upstream-corr-id-456" },
+    });
+    const id = initializeAdminCorrelationId(request);
+    expect(id).toBe("upstream-corr-id-456");
+  });
+
+  it("generates a UUID v4 when header is absent", () => {
+    const request = new Request("https://example.com");
+    const id = initializeAdminCorrelationId(request);
+    // UUID v4 format
+    expect(id).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i,
+    );
+  });
+
+  it("generates a UUID v4 when no request is provided", () => {
+    const id = initializeAdminCorrelationId();
+    expect(id).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i,
+    );
+  });
+
+  it("ignores blank x-correlation-id header and generates a UUID instead", () => {
+    const request = new Request("https://example.com", {
+      headers: { "x-correlation-id": "   " },
+    });
+    const id = initializeAdminCorrelationId(request);
+    expect(id).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i,
+    );
+  });
+
+  it("generates unique IDs on successive calls", () => {
+    const a = initializeAdminCorrelationId();
+    const b = initializeAdminCorrelationId();
+    expect(a).not.toBe(b);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// withAdminCorrelation / getAdminCorrelationId
+// ---------------------------------------------------------------------------
+
+describe("withAdminCorrelation", () => {
+  it("makes the correlation ID available inside the scope", async () => {
+    await withAdminCorrelation("test-corr-789", async () => {
+      const id = getAdminCorrelationId();
+      expect(id).toBe("test-corr-789");
+    });
+  });
+
+  it("returns the value produced by fn", async () => {
+    const result = await withAdminCorrelation("corr-111", async () => 42);
+    expect(result).toBe(42);
+  });
+
+  it("propagates the ID through nested async continuations", async () => {
+    const ids: string[] = [];
+
+    await withAdminCorrelation("nested-corr", async () => {
+      ids.push(getAdminCorrelationId()!);
+      await Promise.resolve(); // suspension point
+      ids.push(getAdminCorrelationId()!);
+    });
+
+    expect(ids).toEqual(["nested-corr", "nested-corr"]);
+  });
+
+  it("isolates scopes — inner scope does not bleed into outer scope", async () => {
+    let outerIdAfterInner: string | undefined;
+
+    await withAdminCorrelation("outer", async () => {
+      await withAdminCorrelation("inner", async () => {
+        expect(getAdminCorrelationId()).toBe("inner");
+      });
+      outerIdAfterInner = getAdminCorrelationId();
+    });
+
+    expect(outerIdAfterInner).toBe("outer");
+  });
+
+  it("two concurrent scopes carry independent IDs", async () => {
+    const aIds: string[] = [];
+    const bIds: string[] = [];
+
+    await Promise.all([
+      withAdminCorrelation("scope-A", async () => {
+        await Promise.resolve();
+        aIds.push(getAdminCorrelationId()!);
+      }),
+      withAdminCorrelation("scope-B", async () => {
+        await Promise.resolve();
+        bIds.push(getAdminCorrelationId()!);
+      }),
+    ]);
+
+    expect(aIds).toEqual(["scope-A"]);
+    expect(bIds).toEqual(["scope-B"]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getAdminCorrelationId — outside scope
+// ---------------------------------------------------------------------------
+
+describe("getAdminCorrelationId — outside scope", () => {
+  it("returns undefined when called outside a withAdminCorrelation scope", () => {
+    // This test runs at module level — no scope is active
+    const id = getAdminCorrelationId();
+    expect(id).toBeUndefined();
+  });
+});

--- a/apps/admin/src/lib/infrastructure/__tests__/logger.test.ts
+++ b/apps/admin/src/lib/infrastructure/__tests__/logger.test.ts
@@ -1,0 +1,212 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import type { AdminLogEvent } from "../logger";
+
+// ---------------------------------------------------------------------------
+// Isolate feature flag so we can test both paths
+// ---------------------------------------------------------------------------
+
+vi.mock("@/lib/config/feature-flags", () => ({
+  AdminFeatureFlag: {
+    ADMIN_V2_STRUCTURED_LOGGING: "admin_v2_structured_logging",
+  },
+  isAdminFeatureEnabled: vi.fn(),
+}));
+
+import { isAdminFeatureEnabled } from "@/lib/config/feature-flags";
+import { getAdminLogger } from "../logger";
+
+const mockIsEnabled = vi.mocked(isAdminFeatureEnabled);
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function validEvent(): AdminLogEvent {
+  return {
+    correlationId: "corr-abc-123",
+    operationName: "delete_user",
+    adminRole: "SUPER_ADMIN",
+    outcome: "success",
+    durationMs: 42,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Structured logger (flag ON)
+// ---------------------------------------------------------------------------
+
+describe("getAdminLogger — structured mode (flag enabled)", () => {
+  let stdoutSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    mockIsEnabled.mockReturnValue(true);
+    stdoutSpy = vi
+      .spyOn(process.stdout, "write")
+      .mockImplementation(() => true);
+  });
+
+  afterEach(() => {
+    stdoutSpy.mockRestore();
+    vi.clearAllMocks();
+  });
+
+  it("emits JSON to stdout for info()", () => {
+    const logger = getAdminLogger();
+    logger.info(validEvent());
+
+    expect(stdoutSpy).toHaveBeenCalledOnce();
+    const raw = String(stdoutSpy.mock.calls[0]![0]);
+    const parsed = JSON.parse(raw.trim());
+
+    expect(parsed.level).toBe("info");
+    expect(parsed.correlationId).toBe("corr-abc-123");
+    expect(parsed.operationName).toBe("delete_user");
+    expect(parsed.adminRole).toBe("SUPER_ADMIN");
+    expect(parsed.outcome).toBe("success");
+    expect(parsed.durationMs).toBe(42);
+    expect(parsed.service).toBe("apps/admin");
+    expect(parsed.timestamp).toBeDefined();
+  });
+
+  it("emits JSON to stdout for warn()", () => {
+    const logger = getAdminLogger();
+    logger.warn({ ...validEvent(), outcome: "domain_error" });
+
+    const raw = String(stdoutSpy.mock.calls[0]![0]);
+    const parsed = JSON.parse(raw.trim());
+    expect(parsed.level).toBe("warn");
+    expect(parsed.outcome).toBe("domain_error");
+  });
+
+  it("emits JSON with errorMessage for error()", () => {
+    const logger = getAdminLogger();
+    logger.error({
+      ...validEvent(),
+      outcome: "internal_error",
+      errorMessage: "boom",
+    });
+
+    const raw = String(stdoutSpy.mock.calls[0]![0]);
+    const parsed = JSON.parse(raw.trim());
+    expect(parsed.level).toBe("error");
+    expect(parsed.errorMessage).toBe("boom");
+  });
+
+  it("includes optional fields when provided", () => {
+    const logger = getAdminLogger();
+    logger.info({
+      ...validEvent(),
+      httpStatus: 403,
+      errorCode: "FORBIDDEN",
+      resourceType: "user",
+      resourceId: "user-uuid-999",
+      meta: { reason: "policy denied" },
+    });
+
+    const raw = String(stdoutSpy.mock.calls[0]![0]);
+    const parsed = JSON.parse(raw.trim());
+    expect(parsed.httpStatus).toBe(403);
+    expect(parsed.errorCode).toBe("FORBIDDEN");
+    expect(parsed.resourceType).toBe("user");
+    expect(parsed.resourceId).toBe("user-uuid-999");
+    expect(parsed.meta.reason).toBe("policy denied");
+  });
+
+  it("strips PII keys from meta at runtime", () => {
+    const logger = getAdminLogger();
+    // Cast to bypass TS type guard — simulating a runtime call that bypasses types
+    (logger.info as (e: Record<string, unknown>) => void)({
+      correlationId: "corr-123",
+      operationName: "test_op",
+      adminRole: "ADMIN",
+      outcome: "success",
+      durationMs: 5,
+      meta: {
+        userId: "should-be-stripped",
+        email: "should-be-stripped@example.com",
+        reason: "should-survive",
+      },
+    });
+
+    const raw = String(stdoutSpy.mock.calls[0]![0]);
+    const parsed = JSON.parse(raw.trim());
+
+    expect(parsed.meta).not.toHaveProperty("userId");
+    expect(parsed.meta).not.toHaveProperty("email");
+    expect(parsed.meta.reason).toBe("should-survive");
+  });
+
+  it("omits meta entirely when meta is empty after stripping", () => {
+    const logger = getAdminLogger();
+    logger.info({ ...validEvent(), meta: {} });
+
+    const raw = String(stdoutSpy.mock.calls[0]![0]);
+    const parsed = JSON.parse(raw.trim());
+    expect(parsed).not.toHaveProperty("meta");
+  });
+
+  it("omits optional undefined fields from JSON output", () => {
+    const logger = getAdminLogger();
+    logger.info(validEvent()); // no httpStatus, errorCode, resourceType, resourceId
+
+    const raw = String(stdoutSpy.mock.calls[0]![0]);
+    const parsed = JSON.parse(raw.trim());
+    expect(parsed).not.toHaveProperty("httpStatus");
+    expect(parsed).not.toHaveProperty("errorCode");
+    expect(parsed).not.toHaveProperty("resourceType");
+    expect(parsed).not.toHaveProperty("resourceId");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Console fallback (flag OFF)
+// ---------------------------------------------------------------------------
+
+describe("getAdminLogger — fallback mode (flag disabled)", () => {
+  let logSpy: ReturnType<typeof vi.spyOn>;
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+  let errorSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    mockIsEnabled.mockReturnValue(false);
+    logSpy = vi.spyOn(console, "log").mockImplementation(() => undefined);
+    warnSpy = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    errorSpy = vi.spyOn(console, "error").mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    logSpy.mockRestore();
+    warnSpy.mockRestore();
+    errorSpy.mockRestore();
+    vi.clearAllMocks();
+  });
+
+  it("routes info() to console.log", () => {
+    const logger = getAdminLogger();
+    logger.info(validEvent());
+    expect(logSpy).toHaveBeenCalledOnce();
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it("routes warn() to console.warn", () => {
+    const logger = getAdminLogger();
+    logger.warn(validEvent());
+    expect(warnSpy).toHaveBeenCalledOnce();
+  });
+
+  it("routes error() to console.error", () => {
+    const logger = getAdminLogger();
+    logger.error(validEvent());
+    expect(errorSpy).toHaveBeenCalledOnce();
+  });
+
+  it("does NOT write to process.stdout", () => {
+    const stdoutSpy = vi
+      .spyOn(process.stdout, "write")
+      .mockImplementation(() => true);
+    const logger = getAdminLogger();
+    logger.info(validEvent());
+    expect(stdoutSpy).not.toHaveBeenCalled();
+    stdoutSpy.mockRestore();
+  });
+});

--- a/apps/admin/src/lib/infrastructure/correlation.ts
+++ b/apps/admin/src/lib/infrastructure/correlation.ts
@@ -1,0 +1,74 @@
+/**
+ * Admin correlation ID threading — ADR-ADMIN-003 §7.2
+ *
+ * Provides an AsyncLocalStorage-backed correlation ID that is threaded
+ * through every structured log event in the action and service layers.
+ *
+ * Usage:
+ *   const correlationId = initializeAdminCorrelationId(request);
+ *   await withAdminCorrelation(correlationId, async () => {
+ *     // All calls within this scope share the same correlationId
+ *     const id = getAdminCorrelationId(); // returns correlationId
+ *   });
+ *
+ * In server actions, safeAction initialises the correlation ID from the
+ * context it already owns (AdminActionContext.correlationId) and stores it
+ * in the AsyncLocalStorage for downstream code to read without prop-drilling.
+ */
+
+import { AsyncLocalStorage } from "async_hooks";
+
+// ---------------------------------------------------------------------------
+// Storage
+// ---------------------------------------------------------------------------
+
+const correlationStorage = new AsyncLocalStorage<string>();
+
+// ---------------------------------------------------------------------------
+// Header key — must match any upstream gateway or load-balancer convention
+// ---------------------------------------------------------------------------
+
+const CORRELATION_HEADER = "x-correlation-id" as const;
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Extracts the correlation ID from an incoming request header, or generates
+ * a fresh UUID v4 if none is present.
+ *
+ * Call once at the adapter boundary (route handler or server action entry).
+ */
+export function initializeAdminCorrelationId(request?: Request): string {
+  if (request) {
+    const fromHeader = request.headers.get(CORRELATION_HEADER);
+    if (fromHeader && fromHeader.trim().length > 0) {
+      return fromHeader.trim();
+    }
+  }
+  return crypto.randomUUID();
+}
+
+/**
+ * Runs `fn` inside an AsyncLocalStorage context that carries `correlationId`.
+ * Any code that calls `getAdminCorrelationId()` inside `fn` — including
+ * async continuations — will receive the same ID.
+ */
+export async function withAdminCorrelation<T>(
+  correlationId: string,
+  fn: () => Promise<T>,
+): Promise<T> {
+  return correlationStorage.run(correlationId, fn);
+}
+
+/**
+ * Reads the correlation ID from the current AsyncLocalStorage context.
+ * Returns `undefined` if called outside a `withAdminCorrelation` scope.
+ *
+ * Prefer passing the `correlationId` from `AdminActionContext` directly;
+ * use this only when the context is unavailable (e.g. repository helpers).
+ */
+export function getAdminCorrelationId(): string | undefined {
+  return correlationStorage.getStore();
+}

--- a/apps/admin/src/lib/infrastructure/logger.ts
+++ b/apps/admin/src/lib/infrastructure/logger.ts
@@ -1,0 +1,177 @@
+/**
+ * Admin structured logger — ADR-ADMIN-003 §7.1
+ *
+ * PII exclusion is enforced at the type level: the `AdminLogEvent` type
+ * explicitly omits fields that carry identity data (userId, email, phone,
+ * nationalId, clerkId, userEmail).  Adapter layers (safeAction, route
+ * handlers) emit structured events; service and repository layers do not log.
+ *
+ * The logger is gated behind the `admin_v2_structured_logging` feature flag.
+ * When the flag is disabled the logger falls back to `console.log` so existing
+ * behaviour is preserved without any code changes at call sites.
+ */
+
+import {
+  AdminFeatureFlag,
+  isAdminFeatureEnabled,
+} from "@/lib/config/feature-flags";
+
+// ---------------------------------------------------------------------------
+// Outcome type
+// ---------------------------------------------------------------------------
+
+export type AdminLogOutcome =
+  | "success"
+  | "domain_error"
+  | "internal_error"
+  | "unauthorized"
+  | "forbidden"
+  | "validation_error"
+  | "rate_limited"
+  | "session_stale";
+
+// ---------------------------------------------------------------------------
+// PII exclusion — these keys are prohibited at the type level
+// ---------------------------------------------------------------------------
+
+type ProhibitedPiiKeys =
+  | "userId"
+  | "email"
+  | "phone"
+  | "nationalId"
+  | "clerkId"
+  | "userEmail"
+  | "adminEmail"
+  | "userPhone"
+  | "firstName"
+  | "lastName";
+
+/**
+ * Required fields for every structured admin log event.
+ * `adminRole` is safe to log — it is a capability enum, not identity.
+ */
+export type AdminLogEvent = {
+  correlationId: string;
+  operationName: string;
+  adminRole: string;
+  outcome: AdminLogOutcome;
+  durationMs: number;
+  httpStatus?: number;
+  errorCode?: string;
+  resourceType?: string;
+  resourceId?: string;
+  /** Free-form Class C/D metadata — PII keys are excluded by type constraint. */
+  meta?: Omit<Record<string, unknown>, ProhibitedPiiKeys>;
+};
+
+// ---------------------------------------------------------------------------
+// Logger interface
+// ---------------------------------------------------------------------------
+
+export interface AdminLogger {
+  info(event: AdminLogEvent): void;
+  warn(event: AdminLogEvent): void;
+  error(event: AdminLogEvent & { errorMessage?: string }): void;
+}
+
+// ---------------------------------------------------------------------------
+// Console-fallback logger (used when flag is disabled)
+// ---------------------------------------------------------------------------
+
+function consoleFallbackLogger(): AdminLogger {
+  return {
+    info(event) {
+      console.log("[admin]", JSON.stringify(event));
+    },
+    warn(event) {
+      console.warn("[admin]", JSON.stringify(event));
+    },
+    error(event) {
+      console.error("[admin]", JSON.stringify(event));
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Structured JSON logger (used when flag is enabled)
+// ---------------------------------------------------------------------------
+
+function structuredLogger(): AdminLogger {
+  function emit(
+    level: "info" | "warn" | "error",
+    event: AdminLogEvent & { errorMessage?: string },
+  ): void {
+    // Sanitise: strip any PII keys that slip through at runtime
+    const prohibitedRuntimeKeys = new Set<string>([
+      "userId",
+      "email",
+      "phone",
+      "nationalId",
+      "clerkId",
+      "userEmail",
+      "adminEmail",
+      "userPhone",
+      "firstName",
+      "lastName",
+    ]);
+
+    const safeMeta: Record<string, unknown> = {};
+    if (event.meta) {
+      for (const [k, v] of Object.entries(event.meta)) {
+        if (!prohibitedRuntimeKeys.has(k)) {
+          safeMeta[k] = v;
+        }
+      }
+    }
+
+    const entry = {
+      level,
+      timestamp: new Date().toISOString(),
+      service: "apps/admin",
+      correlationId: event.correlationId,
+      operationName: event.operationName,
+      adminRole: event.adminRole,
+      outcome: event.outcome,
+      durationMs: event.durationMs,
+      ...(event.httpStatus !== undefined
+        ? { httpStatus: event.httpStatus }
+        : {}),
+      ...(event.errorCode !== undefined ? { errorCode: event.errorCode } : {}),
+      ...(event.resourceType !== undefined
+        ? { resourceType: event.resourceType }
+        : {}),
+      ...(event.resourceId !== undefined
+        ? { resourceId: event.resourceId }
+        : {}),
+      ...(event.errorMessage !== undefined
+        ? { errorMessage: event.errorMessage }
+        : {}),
+      ...(Object.keys(safeMeta).length > 0 ? { meta: safeMeta } : {}),
+    };
+
+    // Write JSON to stdout; in production this is captured by the log aggregator.
+    process.stdout.write(JSON.stringify(entry) + "\n");
+  }
+
+  return {
+    info: (event) => emit("info", event),
+    warn: (event) => emit("warn", event),
+    error: (event) => emit("error", event),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Factory — returns the appropriate implementation based on the feature flag
+// ---------------------------------------------------------------------------
+
+/**
+ * Returns the active admin logger.
+ *
+ * Call once per action execution — do not hold a reference across requests.
+ */
+export function getAdminLogger(): AdminLogger {
+  if (isAdminFeatureEnabled(AdminFeatureFlag.ADMIN_V2_STRUCTURED_LOGGING)) {
+    return structuredLogger();
+  }
+  return consoleFallbackLogger();
+}

--- a/apps/admin/src/lib/observability/__tests__/operation-names.test.ts
+++ b/apps/admin/src/lib/observability/__tests__/operation-names.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect } from "vitest";
+import {
+  AdminOperationName,
+  isRegisteredOperationName,
+  type AdminOperationName as AdminOperationNameType,
+} from "../operation-names";
+
+// ---------------------------------------------------------------------------
+// Registry shape
+// ---------------------------------------------------------------------------
+
+describe("AdminOperationName registry", () => {
+  it("exports a non-empty const object", () => {
+    expect(Object.keys(AdminOperationName).length).toBeGreaterThan(0);
+  });
+
+  it("all values are lower_snake_case strings", () => {
+    for (const [key, value] of Object.entries(AdminOperationName)) {
+      expect(typeof value).toBe("string");
+      expect(value).toMatch(/^[a-z][a-z0-9_]*$/);
+      // No capital letters in values
+      expect(value).toBe(value.toLowerCase());
+      void key; // suppress unused warning
+    }
+  });
+
+  it("all values are unique (no duplicate operation names)", () => {
+    const values = Object.values(AdminOperationName);
+    const unique = new Set(values);
+    expect(unique.size).toBe(values.length);
+  });
+
+  it("all values follow <verb>_<resource> format (contain at least one underscore)", () => {
+    for (const value of Object.values(AdminOperationName)) {
+      expect(value).toContain("_");
+    }
+  });
+
+  // ---- Required domain coverage -------------------------------------------
+
+  it("covers required user operations", () => {
+    expect(AdminOperationName.DELETE_USER).toBe("delete_user");
+    expect(AdminOperationName.BULK_DELETE_USERS).toBe("bulk_delete_users");
+    expect(AdminOperationName.INVITE_USER).toBe("invite_user");
+    expect(AdminOperationName.RESET_CREDENTIALS).toBe("reset_credentials");
+    expect(AdminOperationName.ASSIGN_ROLE).toBe("assign_role");
+  });
+
+  it("covers required verification operations", () => {
+    expect(AdminOperationName.VERIFY_ENTITY).toBe("verify_entity");
+    expect(AdminOperationName.VERIFY_DOCUMENT).toBe("verify_document");
+    expect(AdminOperationName.BATCH_VERIFY_DOCUMENTS).toBe(
+      "batch_verify_documents",
+    );
+    expect(AdminOperationName.BATCH_VERIFY_ENTITIES).toBe(
+      "batch_verify_entities",
+    );
+  });
+
+  it("covers required audit operations", () => {
+    expect(AdminOperationName.QUERY_AUDIT_LOG).toBe("query_audit_log");
+    expect(AdminOperationName.GET_AUDIT_STATS).toBe("get_audit_stats");
+    expect(AdminOperationName.EXPORT_AUDIT_LOG).toBe("export_audit_log");
+  });
+
+  it("covers required finance operations", () => {
+    expect(AdminOperationName.GET_FINANCE_OVERVIEW).toBe(
+      "get_finance_overview",
+    );
+  });
+
+  // ---- Type assignability -------------------------------------------------
+
+  it("all values are assignable to AdminOperationNameType", () => {
+    // Compile-time check via assignment — if this compiles, the type is correct
+    const sample: AdminOperationNameType = AdminOperationName.DELETE_USER;
+    expect(sample).toBe("delete_user");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// isRegisteredOperationName
+// ---------------------------------------------------------------------------
+
+describe("isRegisteredOperationName", () => {
+  it("returns true for every registered value", () => {
+    for (const value of Object.values(AdminOperationName)) {
+      expect(isRegisteredOperationName(value)).toBe(true);
+    }
+  });
+
+  it("returns false for an unregistered string", () => {
+    expect(isRegisteredOperationName("not_a_real_op")).toBe(false);
+  });
+
+  it("returns false for an empty string", () => {
+    expect(isRegisteredOperationName("")).toBe(false);
+  });
+
+  it("returns false for a partial match (prefix of a real name)", () => {
+    // "delete" is not registered, "delete_user" is
+    expect(isRegisteredOperationName("delete")).toBe(false);
+  });
+
+  it("is case-sensitive — upper-case variant is not registered", () => {
+    expect(isRegisteredOperationName("DELETE_USER")).toBe(false);
+  });
+});

--- a/apps/admin/src/lib/observability/operation-names.ts
+++ b/apps/admin/src/lib/observability/operation-names.ts
@@ -1,0 +1,105 @@
+/**
+ * Admin operation name registry — ADR-ADMIN-003 §7.3
+ *
+ * Every admin operation that emits a structured log event MUST use a name
+ * from this registry.  Operation names are stable join keys across log
+ * aggregation, alerting, and audit dashboards — renaming one is a breaking
+ * observability change that requires coordinated dashboard updates.
+ *
+ * Format: <verb>_<resource>  (lower_snake_case, present tense)
+ *
+ * When adding a new operation:
+ *   1. Add the constant here.
+ *   2. Update ADR-ADMIN-003.md Operation Name Registry section.
+ *   3. Update any dashboard/alert rules that join on operationName.
+ */
+
+// ---------------------------------------------------------------------------
+// Registry
+// ---------------------------------------------------------------------------
+
+export const AdminOperationName = {
+  // ---- Users (Tier 1) -------------------------------------------------------
+  LIST_USERS: "list_users",
+  GET_USER_DETAIL: "get_user_detail",
+  DELETE_USER: "delete_user",
+  BULK_DELETE_USERS: "bulk_delete_users",
+  INVITE_USER: "invite_user",
+  RESET_CREDENTIALS: "reset_credentials",
+  ASSIGN_ROLE: "assign_role",
+
+  // ---- Verification (Tier 1) ------------------------------------------------
+  LIST_PENDING_VERIFICATIONS: "list_pending_verifications",
+  GET_VERIFICATION_STATS: "get_verification_stats",
+  GET_VERIFICATION_DETAILS: "get_verification_details",
+  VERIFY_ENTITY: "verify_entity",
+  VERIFY_DOCUMENT: "verify_document",
+  BATCH_VERIFY_DOCUMENTS: "batch_verify_documents",
+  BATCH_VERIFY_ENTITIES: "batch_verify_entities",
+  VERIFY_PROFESSIONAL: "verify_professional",
+
+  // ---- Audit (Tier 1) -------------------------------------------------------
+  QUERY_AUDIT_LOG: "query_audit_log",
+  GET_AUDIT_STATS: "get_audit_stats",
+  GET_AUDIT_ACTIONS: "get_audit_actions",
+  EXPORT_AUDIT_LOG: "export_audit_log",
+
+  // ---- Finance (Tier 1) -----------------------------------------------------
+  GET_FINANCE_OVERVIEW: "get_finance_overview",
+  GET_ANALYTICS: "get_analytics",
+
+  // ---- Content (Tier 2) -----------------------------------------------------
+  LIST_STORES: "list_stores",
+  GET_STORE_DETAIL: "get_store_detail",
+  UPDATE_STORE: "update_store",
+  DELETE_STORE: "delete_store",
+  LIST_PROPERTIES: "list_properties",
+  GET_PROPERTY_DETAIL: "get_property_detail",
+  UPDATE_PROPERTY: "update_property",
+  DELETE_PROPERTY: "delete_property",
+  LIST_PROJECTS: "list_projects",
+  GET_PROJECT_DETAIL: "get_project_detail",
+  UPDATE_PROJECT: "update_project",
+  DELETE_PROJECT: "delete_project",
+
+  // ---- Leads / Services / Professionals (Tier 2) ----------------------------
+  LIST_LEADS: "list_leads",
+  GET_LEAD_DETAIL: "get_lead_detail",
+  UPDATE_LEAD: "update_lead",
+  LIST_SERVICES: "list_services",
+  GET_SERVICE_DETAIL: "get_service_detail",
+  UPDATE_SERVICE: "update_service",
+  LIST_PROFESSIONALS: "list_professionals",
+  GET_PROFESSIONAL_DETAIL: "get_professional_detail",
+  UPDATE_PROFESSIONAL: "update_professional",
+
+  // ---- Compliance / GDPR (Tier 1) -------------------------------------------
+  GET_COMPLIANCE_QUEUE: "get_compliance_queue",
+  PROCESS_COMPLIANCE_REQUEST: "process_compliance_request",
+
+  // ---- Settings (Tier 1) ----------------------------------------------------
+  GET_SYSTEM_SETTINGS: "get_system_settings",
+  UPDATE_SYSTEM_SETTINGS: "update_system_settings",
+
+  // ---- Dashboard ------------------------------------------------------------
+  GET_DASHBOARD_STATS: "get_dashboard_stats",
+} as const;
+
+export type AdminOperationName =
+  (typeof AdminOperationName)[keyof typeof AdminOperationName];
+
+// ---------------------------------------------------------------------------
+// Validation helper — confirms a string is a registered operation name
+// ---------------------------------------------------------------------------
+
+const _registeredNames = new Set<string>(Object.values(AdminOperationName));
+
+/**
+ * Type guard that confirms `value` is a registered AdminOperationName.
+ * Use in tests and drift-check scripts to catch unregistered operation names.
+ */
+export function isRegisteredOperationName(
+  value: string,
+): value is AdminOperationName {
+  return _registeredNames.has(value);
+}


### PR DESCRIPTION
### Phase 7 - Observability foundation

### Added 

- Added `src/lib/infrastructure/logger.ts` implementing ADR-ADMIN-003: `getAdminLogger()` returns a feature-flag-gated structured logger with PII exclusion enforced at the type level (keys `userId`, `email`, `phone`, `nationalId`, `clerkId`, `userEmail`, `adminEmail`, `userPhone`, `firstName`, `lastName` are rejected). Structured mode writes JSON to stdout; fallback mode delegates to `console.log/warn/error` when `admin_v2_structured_logging` is disabled.
- Added `src/lib/infrastructure/correlation.ts` implementing ADR-ADMIN-003 §7.2: `initializeAdminCorrelationId()` reads `x-correlation-id` from request headers or generates UUID v4; `withAdminCorrelation()` threads the ID through async continuations via `AsyncLocalStorage`; `getAdminCorrelationId()` reads the active ID without prop-drilling.
- Added `src/lib/observability/operation-names.ts` implementing ADR-ADMIN-003 §7.3: typed `AdminOperationName` const registry with 40+ stable `<verb>_<resource>` operation names covering users, verification, audit, finance, content, leads/services, compliance, settings, and dashboard. Added `isRegisteredOperationName()` guard for drift-check use.

### Changed 

- Integrated structured logger into `safeAction` and `safeVerificationAction` in `shared.ts`: every terminal outcome path (unauthorized, forbidden, session_stale, rate_limited, success, internal_error) now emits a structured `AdminLogEvent` with `correlationId`, `operationName`, `adminRole`, `outcome`, and `durationMs`.
- `safeAction` now wraps action body execution in `withAdminCorrelation()` so downstream service/repository code can call `getAdminCorrelationId()` without receiving the ID via parameter.
- `correlationId` in the action context is now sourced from a single `crypto.randomUUID()` call at the top of `safeAction`, shared across the log emission and the action body context.

### Tests

- Added `src/lib/infrastructure/__tests__/logger.test.ts` (11 tests): structured-mode JSON output, PII runtime stripping, optional field omission, all log levels, fallback-mode console routing.
- Added `src/lib/infrastructure/__tests__/correlation.test.ts` (11 tests): header extraction, UUID generation, blank-header guard, uniqueness, async propagation, scope isolation, concurrent scope independence, outside-scope undefined return.
- Added `src/lib/observability/__tests__/operation-names.test.ts` (14 tests): lower_snake_case enforcement, uniqueness, verb_resource format, domain coverage assertions, type assignability, `isRegisteredOperationName` guard.

**Files changed:** 

`apps/admin/src/lib/infrastructure/logger.ts` [NEW], `apps/admin/src/lib/infrastructure/correlation.ts` [NEW], `apps/admin/src/lib/observability/operation-names.ts` [NEW], `apps/admin/src/lib/infrastructure/__tests__/logger.test.ts` [NEW], `apps/admin/src/lib/infrastructure/__tests__/correlation.test.ts` [NEW], `apps/admin/src/lib/observability/__tests__/operation-names.test.ts` [NEW], `apps/admin/src/actions/admin/shared.ts`

**Verification:**

- `pnpm run admin:check-types` → pass.
- `pnpm run admin:lint` → pass with known warnings backlog.
- `pnpm run admin:check-env-contract` → pass; 59 boundary keys.
- `pnpm run admin:test:all` → pass; 29 files passed, 213 of 213 tests passed.
- Targeted suite: `pnpm -C apps/admin exec vitest run src/lib/infrastructure/__tests__/logger.test.ts src/lib/infrastructure/__tests__/correlation.test.ts src/lib/observability/__tests__/operation-names.test.ts --pool=threads --maxWorkers=1` → 3 files, 36 tests passed.
l 29 files 213/213 pass | targeted suite 3 files 36/36 pass